### PR TITLE
[HIVE-26166] Make website GDPR compliant

### DIFF
--- a/themes/hive/layouts/partials/head.html
+++ b/themes/hive/layouts/partials/head.html
@@ -37,5 +37,22 @@
         <link rel="mask-icon" href="{{ .Site.BaseURL }}/images/safari-pinned-tab.svg" color="#5bbad5">
         <meta name="msapplication-TileColor" content="#da532c">
         <meta name="theme-color" content="#ffffff">
+        <!-- Matomo -->
+        <script>
+            var _paq = window._paq = window._paq || [];
+            /* We explicitly disable cookie tracking to avoid privacy issues */
+            _paq.push(['disableCookies']);
+            /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+            _paq.push(['trackPageView']);
+            _paq.push(['enableLinkTracking']);
+            (function() {
+                var u="https://analytics.apache.org/";
+                _paq.push(['setTrackerUrl', u+'matomo.php']);
+                _paq.push(['setSiteId', '30']);
+                var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+            })();
+        </script>
+        <!-- End Matomo Code -->
     </head>
 <body>


### PR DESCRIPTION
* 78546f8ebf974073364083d47680e65077054d8d adds the Matomo tracking code to the <head> tag so it's embedded in all pages