### PR TITLE
HIVE-27433 Hive-site: Add redirect to blogs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -48,6 +48,7 @@ theme = 'hive'
     howToRelease = "https://cwiki.apache.org/confluence/display/Hive/HowToRelease"
     gettingStarted = "/developement/gettingstarted/"
     docker = "/developement/quickstart/"
+    blogs = "https://hive.blog.apache.org/"
 
 [params.features]
     acidTxn = "https://cwiki.apache.org/confluence/display/hive/hive+transactions"

--- a/themes/hive/layouts/partials/menu.html
+++ b/themes/hive/layouts/partials/menu.html
@@ -97,6 +97,11 @@
                         </ul>
                     </li>
 
+                    <li class="nav-item dropdown">
+                        <a class="nav-link" href="{{ .Site.Params.navbar.blogs }}" id="navbarDropdown" role="button"  aria-expanded="false">
+                            Blogs
+                        </a>
+                    </li>
 
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">


### PR DESCRIPTION
Adds links to the new hive blogs page: https://hive.blog.apache.org/

Test deployment is here : https://simhadri-g.github.io/hive-site/