### PR TITLE
HIVE-28689: Disable JIRA worklog notifications for GitHub PRs in hive-site repo

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -5,4 +5,4 @@ notifications:
   commits:      commits@hive.apache.org
   issues:       gitbox@hive.apache.org
   pullrequests: gitbox@hive.apache.org
-  jira_options: link label worklog
+  jira_options: link label


### PR DESCRIPTION
Reduce noise and avoid receiving the same notification multiple times.

Currently we receive the notification from four places:
* jira@apache.org
* notifications@github.com
* issues@hive.apache.org
* gitbox@hive.apache.org

After the changes the jira@ and issues@ entries for worklog will go away.