### PR TITLE
HIVE-28714: Disable merge commit option for pull-requests in hive-site

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -6,3 +6,15 @@ notifications:
   issues:       gitbox@hive.apache.org
   pullrequests: gitbox@hive.apache.org
   jira_options: link label
+
+github:
+  description: "Apache Hive Website"
+  homepage: https://hive.apache.org/
+  features:
+    wiki: false
+    issues: false
+    projects: false
+  enabled_merge_buttons:
+    squash:  true
+    merge:   false
+    rebase:  false


### PR DESCRIPTION
Disable merge commit option when merging pull-requests in https://github.com/apache/hive-site to keep the history linear. Incidentally disable the rebase option just to keep things uniform with the main hive repo.