### PR TITLE
HIVE-28437: Update the incorrect name of HiveServer2 on the homepage

### DIFF
--- a/themes/hive/layouts/partials/features.html
+++ b/themes/hive/layouts/partials/features.html
@@ -37,7 +37,7 @@
         <div class="row divs">
             {{- partial "hs2terminal.html" . -}}
             <div class="col-md feature-border">
-                <h2 class="topic-text-style">Hive-Server 2 (HS2)</h2>
+                <h2 class="topic-text-style">HiveServer2 (HS2)</h2>
                 <p>
                     HS2 supports multi-client concurrency and authentication.
                     It is designed to provide better support for open API clients like JDBC and ODBC.


### PR DESCRIPTION
- Update the incorrect name of HiveServer2 on the homepage.
- This is one of the proposals in https://github.com/apache/hive/pull/5629#discussion_r1946176463 .