### PR TITLE
HIVE-28943: Stop keeping removed files from hive-site

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -51,4 +51,3 @@ jobs:
           publish_dir: ./public
           publish_branch: asf-site
           destination_dir: ./
-          keep_files: true

--- a/content/Development/gettingStarted.md
+++ b/content/Development/gettingStarted.md
@@ -2,6 +2,8 @@
 title: "Getting Started"
 date: 2023-01-10T12:35:11+05:30
 draft: false
+aliases:
+- /developement/gettingstarted/
 ---
 
 <!---

--- a/content/Development/qtest.md
+++ b/content/Development/qtest.md
@@ -2,7 +2,6 @@
 title: "Query File Test(qtest)"
 date: 2025-03-28
 draft: false
-aliases: [/qtest.html]
 ---
 
 <!---

--- a/content/Development/quickStart.md
+++ b/content/Development/quickStart.md
@@ -2,6 +2,8 @@
 title: "QuickStarted"
 date: 2023-05-12T17:51:06+05:30
 draft: false
+aliases:
+- /developement/quickstart/
 ---
 
 ### Introduction

--- a/content/Development/versionControl.md
+++ b/content/Development/versionControl.md
@@ -2,7 +2,9 @@
 title: "Version Control"
 date: 2022-09-14T00:34:39+05:30
 draft: false
-aliases: [/version_control.html]
+aliases:
+- /version_control.html
+- /developement/versioncontrol/
 ---
 
 <!---


### PR DESCRIPTION
We keep all outdated content in the `asf-site` branch, which is published to the internet. This is causing some undesirable effects; for example, Google suggests not [/development/quickstart/](https://hive.apache.org/development/quickstart/) but [/developement/quickstart/](https://hive.apache.org/developement/quickstart/), with an extra "e" in the middle, when you search "hive docker".

It looks like [the "keep_files" option is causing this issue](https://github.com/peaceiris/actions-gh-pages?tab=readme-ov-file#%EF%B8%8F-keeping-existing-files-keep_files). Probably, [we don't need it when we use actions-gh-pages with actions-hugo](https://github.com/peaceiris/actions-hugo).

https://issues.apache.org/jira/browse/HIVE-28943