### PR TITLE
HIVE-28950: Restore .asf.yaml in the asf-site branch

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Build
         run: hugo --minify
 
+      - name: Copy .asf.yaml
+        run: cp .asf.yaml ./public
+
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
We have to keep the file on the publish branch.
https://issues.apache.org/jira/browse/HIVE-28950

[This commit](https://github.com/apache/hive-site/commit/80db289d45ca4e4659aa1024832de5ae0d30bbdd) removed `.asf.yaml` with the following content.

```yaml
publish:
  whoami: asf-site

```

I surveyed some sites using `peaceiris/actions-gh-pages`. Most projects copy `.asf.yaml` in the main branch on CI. This will add some redundant YAML entries, but it is likely the easiest.

- https://github.com/apache/dubbo-website/blob/0e2be69763d459ffc07c6bcd9851df7b889fd253/.github/workflows/build_and_deploy_history.yml
    - Output: https://github.com/apache/dubbo-website/blob/asf-site-v2/.asf.yaml
- https://github.com/apache/incubator-baremaps-site/blob/2fd432e9cdb9e154656cd16ba1a458817a543158/.github/workflows/publish.yml
    - Output: https://github.com/apache/incubator-baremaps-site/blob/asf-site/.asf.yaml