### PR TITLE
HIVE-29095: Exploit toc shortcode to generate table of contents in doc pages

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -61,3 +61,11 @@ theme = 'hive'
 
 [outputs]
     home = ["HTML", "RSS", "JSON"]
+[markup]
+    [markup.tableOfContents]
+        endLevel = 3
+        ordered = false
+# Ideally we should start from level 2 but various pages
+# contain multiple level-1 headers at the moment that
+# should be displayed in the table of contents
+        startLevel = 1

--- a/content/community/bylaws.md
+++ b/content/community/bylaws.md
@@ -5,25 +5,13 @@ date: 2024-12-12
 
 # Apache Hive : Bylaws
 
-# Apache Hive Project Bylaws
-
-* [Apache Hive Project Bylaws]({{< ref "#apache-hive-project-bylaws" >}})
-	+ [Roles and Responsibilities]({{< ref "#roles-and-responsibilities" >}})
-		- [Users]({{< ref "#users" >}})
-		- [Committers]({{< ref "#committers" >}})
-		- [Submodule Committers]({{< ref "#submodule-committers" >}})
-		- [Project Management Committee]({{< ref "#project-management-committee" >}})
-	+ [Decision Making]({{< ref "#decision-making" >}})
-		- [Voting]({{< ref "#voting" >}})
-		- [Approvals]({{< ref "#approvals" >}})
-		- [Vetoes]({{< ref "#vetoes" >}})
-		- [Actions]({{< ref "#actions" >}})
-
 This document defines the bylaws under which the Apache Hive project operates. It defines the roles and responsibilities of the project, who may vote, how voting works, how conflicts are resolved, etc.
 
 Hive is a project of the [Apache Software Foundation](http://www.apache.org/foundation/). The foundation holds the copyright on Apache code including the code in the Hive codebase. The [foundation FAQ](http://www.apache.org/foundation/faq.html) explains the operation and background of the foundation.
 
 Hive is typical of Apache projects in that it operates under a set of principles, known collectively as the 'Apache Way'. If you are new to Apache development, please refer to the [Incubator Project](http://incubator.apache.org/) for more information on how Apache projects operate.
+
+{{< toc >}}
 
 ## Roles and Responsibilities
 

--- a/content/docs/latest/158869886.md
+++ b/content/docs/latest/158869886.md
@@ -5,24 +5,10 @@ date: 2024-12-12
 
 # Apache Hive : Enabling gRPC in Hive/Hive Metastore (Proposal)
 
-Contacts: Cameron Moberg (Google), Zhou Fang (Google), Feng Lu (Google), Thejas Nair (Cloudera), Vihang Karajgaonkar (Cloudera), Naveen Gangam (Cloudera)
+{{< toc >}}
 
-Last upated: 7/31/2020
-
-* [Objective]({{< ref "#objective" >}})
-* [Background]({{< ref "#background" >}})
-* [Design]({{< ref "#design" >}})
-	+ [Overview]({{< ref "#overview" >}})
-	+ [Implementation]({{< ref "#implementation" >}})
-		- [Pluggable gRPC Support]({{< ref "#pluggable-grpc-support" >}})
-		- [Hive Metastore Server]({{< ref "#hive-metastore-server" >}})
-			* [Class Change]({{< ref "#class-change" >}})
-			* [Config Changes]({{< ref "#config-changes" >}})
-		- [Hive Metastore Client]({{< ref "#hive-metastore-client" >}})
-			* [Class Change]({{< ref "#class-change" >}})
-			* [Configuration Changes]({{< ref "#configuration-changes" >}})
-* [Summary]({{< ref "#summary" >}})
-* [Future Work]({{< ref "#future-work" >}})
+## Contacts
+Cameron Moberg (Google), Zhou Fang (Google), Feng Lu (Google), Thejas Nair (Cloudera), Vihang Karajgaonkar (Cloudera), Naveen Gangam (Cloudera)
 
 # Objective
 

--- a/content/docs/latest/27837073.md
+++ b/content/docs/latest/27837073.md
@@ -7,8 +7,7 @@ date: 2024-12-12
 
 This project has been abandoned. We're leaving the design doc here in case someone decides to attempt this project in the future.
 
-* [Use Cases]({{< ref "#use-cases" >}})
-* [Requirements]({{< ref "#requirements" >}})
+{{< toc >}}
 
 ## Use Cases
 

--- a/content/docs/latest/283118453.md
+++ b/content/docs/latest/283118453.md
@@ -5,30 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : Hive Transactions (Hive ACID)
 
-# ACID and Transactions in Hive
-
-* [ACID and Transactions in Hive]({{< ref "#acid-and-transactions-in-hive" >}})
-	+ [What is ACID and why should you use it?]({{< ref "#what-is-acid-and-why-should-you-use-it" >}})
-	+ [Limitations]({{< ref "#limitations" >}})
-	+ [Streaming APIs]({{< ref "#streaming-apis" >}})
-	+ [Grammar Changes]({{< ref "#grammar-changes" >}})
-	+ [Basic Design]({{< ref "#basic-design" >}})
-		- [Base and Delta Directories]({{< ref "#base-and-delta-directories" >}})
-		- [Compactor]({{< ref "#compactor" >}})
-			* [Delta File Compaction]({{< ref "#delta-file-compaction" >}})
-			* [Initiator]({{< ref "#initiator" >}})
-			* [Worker]({{< ref "#worker" >}})
-			* [Cleaner]({{< ref "#cleaner" >}})
-			* [AcidHouseKeeperService]({{< ref "#acidhousekeeperservice" >}})
-			* [SHOW COMPACTIONS]({{< ref "#show-compactions" >}})
-		- [Transaction/Lock Manager]({{< ref "#transactionlock-manager" >}})
-	+ [Configuration]({{< ref "#configuration" >}})
-		- [New Configuration Parameters for Transactions]({{< ref "#new-configuration-parameters-for-transactions" >}})
-		- [Configuration Values to Set for Hive ACID (INSERT, UPDATE, DELETE)]({{< ref "#configuration-values-to-set-for-hive-acid--insert,-update,-delete-" >}})
-		- [Configuration Values to Set for Compaction]({{< ref "#configuration-values-to-set-for-compaction" >}})
-		- [Compaction pooling]({{< ref "#compaction-pooling" >}})
-	+ [Table Properties]({{< ref "#table-properties" >}})
-* [Talks and Presentations]({{< ref "#talks-and-presentations" >}})
+{{< toc >}}
 
 ## What is ACID and why should you use it?
 

--- a/content/docs/latest/283118454.md
+++ b/content/docs/latest/283118454.md
@@ -7,16 +7,7 @@ date: 2024-12-12
 
 A Java API focused on mutating (insert/update/delete) records into transactional tables using Hive’s [ACID](https://cwiki.apache.org/confluence/display/Hive/Hive+Transactions) feature. It is introduced in Hive 2.0.0 ([HIVE-10165](https://issues.apache.org/jira/browse/HIVE-10165)).
 
-* [Background]({{< ref "#background" >}})
-* [Structure]({{< ref "#structure" >}})
-* [Data Requirements]({{< ref "#data-requirements" >}})
-* [Streaming Requirements]({{< ref "#streaming-requirements" >}})
-* [Record Layout]({{< ref "#record-layout" >}})
-* [Connection and Transaction Management]({{< ref "#connection-and-transaction-management" >}})
-* [Writing Data]({{< ref "#writing-data" >}})
-	+ [Dynamic Partition Creation]({{< ref "#dynamic-partition-creation" >}})
-* [Reading Data]({{< ref "#reading-data" >}})
-* [Example]({{< ref "#example" >}})
+{{< toc >}}
 
 # Background
 

--- a/content/docs/latest/284790216.md
+++ b/content/docs/latest/284790216.md
@@ -5,11 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : Copy of Hive Schema Tool - [TODO: move it under a 4.0 admin manual page, find a proper name]
 
-* [About]({{< ref "#about" >}})
-* [Metastore Schema Verification]({{< ref "#metastore-schema-verification" >}})
-* [The Hive Schema Tool]({{< ref "#the-hive-schema-tool" >}})
-	+ [The schematool Command]({{< ref "#the-schematool-command" >}})
-	+ [Usage Examples]({{< ref "#usage-examples" >}})
+{{< toc >}}
 
 ## About
 

--- a/content/docs/latest/30151323.md
+++ b/content/docs/latest/30151323.md
@@ -7,12 +7,7 @@ date: 2024-12-12
 
 This document describes enhanced aggregation features for the GROUP BY clause of SELECT statements.
 
-* [GROUPING SETS clause]({{< ref "#grouping-sets-clause" >}})
-* [Grouping__ID function]({{< ref "#grouping__id-function" >}})
-* [Grouping function]({{< ref "#grouping-function" >}})
-* [Cubes and Rollups]({{< ref "#cubes-and-rollups" >}})
-* [hive.new.job.grouping.set.cardinality]({{< ref "#hivenewjobgroupingsetcardinality" >}})
-* [Grouping__ID function (before Hive 2.3.0)]({{< ref "#grouping__id-function-before-hive-230" >}})
+{{< toc >}}
 
 Version
 

--- a/content/docs/latest/44302539.md
+++ b/content/docs/latest/44302539.md
@@ -5,23 +5,14 @@ date: 2024-12-12
 
 # Apache Hive : Hive on Spark: Getting Started
 
-* [Version Compatibility]({{< ref "#version-compatibility" >}})
-* [Spark Installation]({{< ref "#spark-installation" >}})
-* [Configuring YARN]({{< ref "#configuring-yarn" >}})
-* [Configuring Hive]({{< ref "#configuring-hive" >}})
-	+ [Configuration property details]({{< ref "#configuration-property-details" >}})
-* [Configuring Spark]({{< ref "#configuring-spark" >}})
-	+ [Tuning Details]({{< ref "#tuning-details" >}})
-* [Common Issues (Green are resolved, will be removed from this list)]({{< ref "#common-issues-green-are-resolved-will-be-removed-from-this-list" >}})
-* [Recommended Configuration]({{< ref "#recommended-configuration" >}})
-* [Design documents]({{< ref "#design-documents" >}})
-
 Hive on Spark provides Hive with the ability to utilize [Apache Spark](http://spark.apache.org/) as its execution engine.
 
 ```
 set hive.execution.engine=spark;
 ```
 Hive on Spark was added in [HIVE-7292](https://issues.apache.org/jira/browse/HIVE-7292).
+
+{{< toc >}}
 
 ## Version Compatibility
 

--- a/content/docs/latest/45876173.md
+++ b/content/docs/latest/45876173.md
@@ -5,20 +5,9 @@ date: 2024-12-12
 
 # Apache Hive : Hive deprecated authorization mode / Legacy Mode
 
-* [Disclaimer]({{< ref "#disclaimer" >}})
-* [Prerequisites]({{< ref "#prerequisites" >}})
-* [Users, Groups, and Roles]({{< ref "#users-groups-and-roles" >}})
-	+ [Names of Users and Roles]({{< ref "#names-of-users-and-roles" >}})
-* [Creating/Dropping/Using Roles]({{< ref "#creatingdroppingusing-roles" >}})
-	+ [Create/Drop Role]({{< ref "#createdrop-role" >}})
-	+ [Grant/Revoke Roles]({{< ref "#grantrevoke-roles" >}})
-	+ [Viewing Granted Roles]({{< ref "#viewing-granted-roles" >}})
-* [Privileges]({{< ref "#privileges" >}})
-	+ [Grant/Revoke Privileges]({{< ref "#grantrevoke-privileges" >}})
-	+ [Viewing Granted Privileges]({{< ref "#viewing-granted-privileges" >}})
-* [Hive Operations and Required Privileges]({{< ref "#hive-operations-and-required-privileges" >}})
-
 This document describes Hive security using the basic authorization scheme, which regulates access to Hive metadata on the client side. This was the default authorization mode used when authorization was enabled. The default was changed to [SQL Standard authorization]({{< ref "sql-standard-based-hive-authorization_40509928" >}}) in Hive 2.0 ([HIVE-12429](https://issues.apache.org/jira/browse/HIVE-12429)).
+
+{{< toc >}}
 
 ### Disclaimer
 

--- a/content/docs/latest/50858744.md
+++ b/content/docs/latest/50858744.md
@@ -5,15 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : Hive on Spark: Join Design Master
 
-* [Purpose and Prerequisites]({{< ref "#purpose-and-prerequisites" >}})
-* [MapReduce Summary]({{< ref "#mapreduce-summary" >}})
-	+ [Figure 1. Join Processors for Hive on MapReduce]({{< ref "#figure-1-join-processors-for-hive-on-mapreduce" >}})
-* [Tez Comparison]({{< ref "#tez-comparison" >}})
-* [Spark MapJoin]({{< ref "#spark-mapjoin" >}})
-* [Spark Join Design]({{< ref "#spark-join-design" >}})
-	+ [Figure 2: Join Processors for Hive on Spark]({{< ref "#figure-2-join-processors-for-hive-on-spark" >}})
-
-  
+{{< toc >}}
 
 ## Purpose and Prerequisites
 

--- a/content/docs/latest/50860526.md
+++ b/content/docs/latest/50860526.md
@@ -5,22 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : Hybrid Hybrid Grace Hash Join, v1.0
 
-* [Overview]({{< ref "#overview" >}})
-* [Scope]({{< ref "#scope" >}})
-* [Notation and Assumptions]({{< ref "#notation-and-assumptions" >}})
-* [Brief Review on Hash Join Algorithms]({{< ref "#brief-review-on-hash-join-algorithms" >}})
-	+ [Simple Hash Join]({{< ref "#simple-hash-join" >}})
-	+ [GRACE Hash Join]({{< ref "#grace-hash-join" >}})
-	+ [Hybrid GRACE Hash Join]({{< ref "#hybrid-grace-hash-join" >}})
-	+ [Hash Join in Hive]({{< ref "#hash-join-in-hive" >}})
-* [Motivation for “Hybrid Hybrid GRACE Hash Join”]({{< ref "#motivation-for-hybrid-hybrid-grace-hash-join" >}})
-* [Algorithm]({{< ref "#algorithm" >}})
-* [Recursive Hashing and Spilling]({{< ref "#recursive-hashing-and-spilling" >}})
-* [Skewed Data Distribution]({{< ref "#skewed-data-distribution" >}})
-* [Bloom Filter]({{< ref "#bloom-filter" >}})
-* [References]({{< ref "#references" >}})
-
-  
+{{< toc >}}
 
 # Overview
 

--- a/content/docs/latest/accumulointegration_46633569.md
+++ b/content/docs/latest/accumulointegration_46633569.md
@@ -3,24 +3,9 @@ title: "Apache Hive : AccumuloIntegration"
 date: 2024-12-12
 ---
 
-# Apache Hive : AccumuloIntegration
+# Apache Hive : Accumulo Integration
 
-# Hive Accumulo Integration
-
-* [Hive Accumulo Integration]({{< ref "#hive-accumulo-integration" >}})
-	+ [Overview]({{< ref "#overview" >}})
-	+ [Implementation]({{< ref "#implementation" >}})
-	+ [Accumulo Configuration]({{< ref "#accumulo-configuration" >}})
-	+ [Usage]({{< ref "#usage" >}})
-	+ [Column Mapping]({{< ref "#column-mapping" >}})
-	+ [Indexing]({{< ref "#indexing" >}})
-	+ [Other options]({{< ref "#other-options" >}})
-	+ [Examples]({{< ref "#examples" >}})
-		- [Override the Accumulo table name]({{< ref "#override-the-accumulo-table-name" >}})
-		- [Store a Hive map with binary serialization]({{< ref "#store-a-hive-map-with-binary-serialization" >}})
-		- [Register an external table]({{< ref "#register-an-external-table" >}})
-		- [Create an indexed table]({{< ref "#create-an-indexed-table" >}})
-	+ [Acknowledgements]({{< ref "#acknowledgements" >}})
+{{< toc >}}
 
 ## Overview
 

--- a/content/docs/latest/adminmanual-configuration_27362070.md
+++ b/content/docs/latest/adminmanual-configuration_27362070.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : AdminManual Configuration
 
-* [Configuring Hive]({{< ref "#configuring-hive" >}})
-	+ [hive-site.xml and hive-default.xml.template]({{< ref "#hive-sitexml-and-hive-defaultxmltemplate" >}})
-	+ [Temporary Folders]({{< ref "#temporary-folders" >}})
-	+ [Log Files]({{< ref "#log-files" >}})
-	+ [Derby Server Mode]({{< ref "#derby-server-mode" >}})
-	+ [Configuration Variables]({{< ref "#configuration-variables" >}})
-* [Removing Hive Metastore Password from Hive Configuration]({{< ref "#removing-hive-metastore-password-from-hive-configuration" >}})
-* [Configuring HCatalog and WebHCat]({{< ref "#configuring-hcatalog-and-webhcat" >}})
-	+ [HCatalog]({{< ref "#hcatalog" >}})
-	+ [WebHCat]({{< ref "#webhcat" >}})
+{{< toc >}}
 
 ## Configuring Hive
 

--- a/content/docs/latest/adminmanual-installation_27362077.md
+++ b/content/docs/latest/adminmanual-installation_27362077.md
@@ -5,17 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : AdminManual Installation
 
-* [Installing Hive]({{< ref "#installing-hive" >}})
-	+ [Installing from a Tarball]({{< ref "#installing-from-a-tarball" >}})
-	+ [Installing from Source Code (Hive 1.2.0 and Later)]({{< ref "#installing-from-source-code-hive-120-and-later" >}})
-	+ [Installing from Source Code (Hive 0.13.0 and Later)]({{< ref "#installing-from-source-code-hive-0130-and-later" >}})
-	+ [Installing from Source Code (Hive 0.12.0 and Earlier)]({{< ref "#installing-from-source-code-hive-0120-and-earlier" >}})
-* [Next Steps]({{< ref "#next-steps" >}})
-	+ [Hive CLI and Beeline CLI]({{< ref "#hive-cli-and-beeline-cli" >}})
-	+ [Hive Metastore]({{< ref "#hive-metastore" >}})
-* [HCatalog and WebHCat]({{< ref "#hcatalog-and-webhcat" >}})
-	+ [HCatalog]({{< ref "#hcatalog" >}})
-	+ [WebHCat (Templeton)]({{< ref "#webhcat-templeton" >}})
+{{< toc >}}
 
 # Installing Hive
 

--- a/content/docs/latest/adminmanual-metastore-3-0-administration_75978150.md
+++ b/content/docs/latest/adminmanual-metastore-3-0-administration_75978150.md
@@ -5,26 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : AdminManual Metastore 3.0 Administration
 
-Metastore 3.0 Administration
-
-* [Version Note]({{< ref "#version-note" >}})
-* [Introduction]({{< ref "#introduction" >}})
-	+ [Changes From Hive 2 to Hive 3]({{< ref "#changes-from-hive-2-to-hive-3" >}})
-* [General Configuration]({{< ref "#general-configuration" >}})
-* [RDBMS]({{< ref "#rdbms" >}})
-	+ [Option 1: Embedding Derby]({{< ref "#option-1-embedding-derby" >}})
-	+ [Option 2: External RDBMS]({{< ref "#option-2-external-rdbms" >}})
-		- [Supported RDBMSs]({{< ref "#supported-rdbmss" >}})
-	+ [Installing and Upgrading the Metastore Schema]({{< ref "#installing-and-upgrading-the-metastore-schema" >}})
-* [Running the Metastore]({{< ref "#running-the-metastore" >}})
-	+ [Embedded Mode]({{< ref "#embedded-mode" >}})
-	+ [Metastore Server]({{< ref "#metastore-server" >}})
-		- [High Availability]({{< ref "#high-availability" >}})
-		- [Securing the Service]({{< ref "#securing-the-service" >}})
-* [Running the Metastore Without Hive]({{< ref "#running-the-metastore-without-hive" >}})
-* [Performance Optimizations]({{< ref "#performance-optimizations" >}})
-	+ [CachedStore]({{< ref "#cachedstore" >}})
-* [Less Commonly Changed Configuration Parameters]({{< ref "#less-commonly-changed-configuration-parameters" >}})
+{{< toc >}}
 
 ## Version Note
 

--- a/content/docs/latest/adminmanual-metastore-administration_27362076.md
+++ b/content/docs/latest/adminmanual-metastore-administration_27362076.md
@@ -5,23 +5,9 @@ date: 2024-12-12
 
 # Apache Hive : AdminManual Metastore Administration
 
-## Hive Metastore Administration
-
-* [Hive Metastore Administration]({{< ref "#hive-metastore-administration" >}})
-	+ [Introduction]({{< ref "#introduction" >}})
-		- [Basic Configuration Parameters]({{< ref "#basic-configuration-parameters" >}})
-		- [Additional Configuration Parameters]({{< ref "#additional-configuration-parameters" >}})
-		- [Data Nucleus Auto Start]({{< ref "#data-nucleus-auto-start" >}})
-		- [Default Configuration]({{< ref "#default-configuration" >}})
-	+ [Local/Embedded Metastore Database (Derby)]({{< ref "#localembedded-metastore-database-derby" >}})
-	+ [Remote Metastore Database]({{< ref "#remote-metastore-database" >}})
-	+ [Local/Embedded Metastore Server]({{< ref "#localembedded-metastore-server" >}})
-	+ [Remote Metastore Server]({{< ref "#remote-metastore-server" >}})
-		- [Client Configuration Parameters]({{< ref "#client-configuration-parameters" >}})
-	+ [Supported Backend Databases for Metastore]({{< ref "#supported-backend-databases-for-metastore" >}})
-	+ [Metastore Schema Consistency and Upgrades]({{< ref "#metastore-schema-consistency-and-upgrades" >}})
-
 This page only documents the MetaStore in Hive 2.x and earlier. For 3.x and later releases please see [AdminManual Metastore 3.0 Administration]({{< ref "adminmanual-metastore-3-0-administration_75978150" >}})
+
+{{< toc >}}
 
 ### Introduction
 

--- a/content/docs/latest/authdev_27362078.md
+++ b/content/docs/latest/authdev_27362078.md
@@ -5,36 +5,9 @@ date: 2024-12-12
 
 # Apache Hive : AuthDev
 
-**Index**
-
-* [1. Privilege]({{< ref "#1-privilege" >}})
-	+ [1.1 Access Privilege]({{< ref "#11-access-privilege" >}})
-* [2. Hive Operations]({{< ref "#2-hive-operations" >}})
-* [3. Metadata]({{< ref "#3-metadata" >}})
-	+ [3.1 user, group, and roles]({{< ref "#31-user-group-and-roles" >}})
-		- [3.1.1 Role management]({{< ref "#311-role-management" >}})
-		- [3.1.2 role metadata]({{< ref "#312-role-metadata" >}})
-		- [3.1.3 hive role user membership table]({{< ref "#313-hive-role-user-membership-table" >}})
-	+ [3.2 Privileges to be supported by Hive]({{< ref "#32-privileges-to-be-supported-by-hive" >}})
-		- [3.2.1 metadata]({{< ref "#321-metadata" >}})
-* [4. grant/revoke access privilege]({{< ref "#4-grantrevoke-access-privilege" >}})
-	+ [4.1 Privilege names/types:]({{< ref "#41-privilege-namestypes" >}})
-	+ [4.2 show grant]({{< ref "#42-show-grant" >}})
-	+ [4.3 grant/revoke statement]({{< ref "#43-grantrevoke-statement" >}})
-* [5. Authorization verification]({{< ref "#5-authorization-verification" >}})
-	+ [5.1 USER/GROUP/ROLE]({{< ref "#51-usergrouprole" >}})
-	+ [5.2 The verification steps]({{< ref "#52-the-verification-steps" >}})
-	+ [5.3 Examples]({{< ref "#53-examples" >}})
-* [6. Where to add authorization in Hive]({{< ref "#6-where-to-add-authorization-in-hive" >}})
-* [7. Implementation]({{< ref "#7-implementation" >}})
-	+ [7.1 Authenticator interface]({{< ref "#71-authenticator-interface" >}})
-	+ [7.2 Authorization]({{< ref "#72-authorization" >}})
-* [8. Metastore upgrade script for mysql]({{< ref "#8-metastore-upgrade-script-for-mysql" >}})
-* [HDFS Permission]({{< ref "#hdfs-permission" >}})
-
-Authorization modes
-
 This is the design document for the [original Hive authorization mode]({{< ref "45876173" >}}). See [Authorization]({{< ref "languagemanual-authorization_27362032" >}}) for an overview of authorization modes, which include [storage based authorization]({{< ref "storage-based-authorization-in-the-metastore-server_45876440" >}}) and [SQL standards based authorization]({{< ref "sql-standard-based-hive-authorization_40509928" >}}).
+
+{{< toc >}}
 
 # 1. Privilege
 

--- a/content/docs/latest/avroserde_27850707.md
+++ b/content/docs/latest/avroserde_27850707.md
@@ -5,26 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : AvroSerDe
 
-* [Availability]({{< ref "#availability" >}})
-* [Overview – Working with Avro from Hive]({{< ref "#overview-–-working-with-avro-from-hive" >}})
-* [Requirements]({{< ref "#requirements" >}})
-* [Avro to Hive type conversion]({{< ref "#avro-to-hive-type-conversion" >}})
-* [Creating Avro-backed Hive tables]({{< ref "#creating-avro-backed-hive-tables" >}})
-	+ [All Hive versions]({{< ref "#all-hive-versions" >}})
-	+ [Hive 0.14 and later versions]({{< ref "#hive-014-and-later-versions" >}})
-* [Writing tables to Avro files]({{< ref "#writing-tables-to-avro-files" >}})
-	
-		- [Example]({{< ref "#example" >}})+ [All Hive versions]({{< ref "#all-hive-versions" >}})
-	+ [Hive 0.14 and later]({{< ref "#hive-014-and-later" >}})
-	+ [Avro file extension]({{< ref "#avro-file-extension" >}})
-* [Specifying the Avro schema for a table]({{< ref "#specifying-the-avro-schema-for-a-table" >}})
-	+ [Use avro.schema.url]({{< ref "#use-avroschemaurl" >}})
-	+ [Use schema.literal and embed the schema in the create statement]({{< ref "#use-schemaliteral-and-embed-the-schema-in-the-create-statement" >}})
-	+ [Use avro.schema.literal and pass the schema into the script]({{< ref "#use-avroschemaliteral-and-pass-the-schema-into-the-script" >}})
-	+ [Use none to ignore either avro.schema.literal or avro.schema.url]({{< ref "#use-none-to-ignore-either-avroschemaliteral-or-avroschemaurl" >}})
-* [HBase Integration]({{< ref "#hbase-integration" >}})
-* [If something goes wrong]({{< ref "#if-something-goes-wrong" >}})
-* [FAQ]({{< ref "#faq" >}})
+{{< toc >}}
 
 ### Availability
 

--- a/content/docs/latest/column-statistics-in-hive_29131019.md
+++ b/content/docs/latest/column-statistics-in-hive_29131019.md
@@ -5,10 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : Column Statistics in Hive
 
-*** [Introduction]({{< ref "#introduction" >}})
-* [HiveQL changes]({{< ref "#hiveql-changes" >}})
-* [Metastore Schema]({{< ref "#metastore-schema" >}})
-* [Metastore Thrift API]({{< ref "#metastore-thrift-api" >}})**
+{{< toc >}}
 
 ### **Introduction**
 

--- a/content/docs/latest/configuration-properties_27842758.md
+++ b/content/docs/latest/configuration-properties_27842758.md
@@ -5,64 +5,6 @@ date: 2024-12-12
 
 # Apache Hive : Configuration Properties
 
-# Hive Configuration Properties
-
-* [Hive Configuration Properties]({{< ref "#hive-configuration-properties" >}})
-	+ [Query and DDL Execution]({{< ref "#query-and-ddl-execution" >}})
-		- [Datetime]({{< ref "#datetime" >}})
-		- [SerDes and I/O]({{< ref "#serdes-and-io" >}})
-			* [SerDes]({{< ref "#serdes" >}})
-			* [I/O]({{< ref "#io" >}})
-		- [File Formats]({{< ref "#file-formats" >}})
-			* [RCFile Format]({{< ref "#rcfile-format" >}})
-			* [ORC File Format]({{< ref "#orc-file-format" >}})
-			* [Parquet]({{< ref "#parquet" >}})
-			* [Avro]({{< ref "#avro" >}})
-		- [Vectorization]({{< ref "#vectorization" >}})
-	+ [MetaStore]({{< ref "#metastore" >}})
-		- [Hive Metastore Connection Pooling Configuration]({{< ref "#hive-metastore-connection-pooling-configuration" >}})
-		- [Hive Metastore HBase]({{< ref "#hive-metastore-hbase" >}})
-	+ [HiveServer2]({{< ref "#hiveserver2" >}})
-		- [HiveServer2 Web UI]({{< ref "#hiveserver2-web-ui" >}})
-	+ [Spark]({{< ref "#spark" >}})
-		- [Remote Spark Driver]({{< ref "#remote-spark-driver" >}})
-	+ [Tez]({{< ref "#tez" >}})
-	+ [LLAP]({{< ref "#llap" >}})
-		- [LLAP Client]({{< ref "#llap-client" >}})
-		- [LLAP Web Services]({{< ref "#llap-web-services" >}})
-		- [LLAP Cache]({{< ref "#llap-cache" >}})
-		- [LLAP I/O]({{< ref "#llap-io" >}})
-		- [LLAP CBO]({{< ref "#llap-cbo" >}})
-		- [LLAP Metrics]({{< ref "#llap-metrics" >}})
-		- [LLAP UDF Security]({{< ref "#llap-udf-security" >}})
-		- [LLAP Security]({{< ref "#llap-security" >}})
-	+ [Transactions and Compactor]({{< ref "#transactions-and-compactor" >}})
-		- [Transactions]({{< ref "#transactions" >}})
-		- [Compactor]({{< ref "#compactor" >}})
-		- [Compaction History]({{< ref "#compaction-history" >}})
-	+ [Indexing]({{< ref "#indexing" >}})
-	+ [Statistics]({{< ref "#statistics" >}})
-		- [Runtime Filtering]({{< ref "#runtime-filtering" >}})
-	+ [Authentication and Authorization]({{< ref "#authentication-and-authorization" >}})
-		- [Restricted/Hidden/Internal List and Whitelist]({{< ref "#restrictedhiddeninternal-list-and-whitelist" >}})
-			* [Whitelist for SQL Standard Based Hive Authorization]({{< ref "#whitelist-for-sql-standard-based-hive-authorization" >}})
-		- [Hive Client Security]({{< ref "#hive-client-security" >}})
-		- [Hive Metastore Security]({{< ref "#hive-metastore-security" >}})
-		- [SQL Standard Based Authorization]({{< ref "#sql-standard-based-authorization" >}})
-	+ [Archiving]({{< ref "#archiving" >}})
-	+ [Locking]({{< ref "#locking" >}})
-	+ [Metrics]({{< ref "#metrics" >}})
-	+ [Clustering]({{< ref "#clustering" >}})
-	+ [Regions]({{< ref "#regions" >}})
-	+ [Command Line Interface]({{< ref "#command-line-interface" >}})
-	+ [HBase StorageHandler]({{< ref "#hbase-storagehandler" >}})
-	+ [Hive Web Interface (HWI) (component removed as of Hive 2.2.0)]({{< ref "#hive-web-interface--hwi---component-removed-as-of-hive-2-2-0-" >}})
-	+ [Replication]({{< ref "#replication" >}})
-	+ [Blobstore (i.e. Amazon S3)]({{< ref "#blobstore-ie-amazon-s3" >}})
-	+ [Test Properties]({{< ref "#test-properties" >}})
-* [HCatalog Configuration Properties]({{< ref "#hcatalog-configuration-properties" >}})
-* [WebHCat Configuration Properties]({{< ref "#webhcat-configuration-properties" >}})
-
 This document describes the Hive user configuration properties (sometimes called *parameters*, *variables*, or *options*), and notes which releases introduced new properties.
 
 The canonical list of configuration properties is managed in the `HiveConf` Java class, so refer to the `HiveConf.java` file for a complete list of configuration properties available in your Hive release.
@@ -72,6 +14,8 @@ For information about how to use these configuration properties, see [Configurin
 Version information
 
 As of Hive 0.14.0 ( [HIVE-7211](https://issues.apache.org/jira/browse/HIVE-7211) ), a configuration name that starts with "hive." is regarded as a Hive system property.  With the [hive.conf.validation]({{< ref "#hiveconfvalidation" >}}) option true (default), any attempts to set a configuration property that starts with "hive." which is not registered to the Hive system will throw an exception.
+
+{{< toc >}}
 
 ## Query and DDL Execution
 
@@ -1403,19 +1347,7 @@ If set to true, order/sort by without limit in subqueries and views will be remo
 ##### hive.datetime.formatter
 
 * Default Value: `DATETIME`
-* Added In: Hive 4.0.0 with 
-
-[![](https://issues.apache.org/jira/secure/viewavatar?size=xsmall&avatarId=21140&avatarType=issuetype)HIVE-25576](https://issues.apache.org/jira/browse/HIVE-25576?src=confmacro)
- -
- Configurable datetime formatter for unix_timestamp, from_unixtime
-Closed
-
-,
-
-[![](https://issues.apache.org/jira/secure/viewavatar?size=xsmall&avatarId=21140&avatarType=issuetype)HIVE-27673](https://issues.apache.org/jira/browse/HIVE-27673?src=confmacro)
- -
- Configurable datetime formatter for date_format
-Closed
+* Added In: Hive 4.0.0 with [HIVE-25576](https://issues.apache.org/jira/browse/HIVE-25576), [HIVE-27673](https://issues.apache.org/jira/browse/HIVE-27673)
 
 The formatter to use for handling datetime values. The possible values are:
 

--- a/content/docs/latest/cost-based-optimization-in-hive_42566775.md
+++ b/content/docs/latest/cost-based-optimization-in-hive_42566775.md
@@ -5,14 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : Cost-based optimization in Hive
 
-* [Abstract]({{< ref "#abstract" >}})
-* [1. INTRODUCTION]({{< ref "#1-introduction" >}})
-* [2. RELATED WORK]({{< ref "#2-related-work" >}})
-* [3. BACKGROUND]({{< ref "#3-background" >}})
-* [4. Implementation details]({{< ref "#4-implementation-details" >}})
-* [5. Phase 1 – Work Items]({{< ref "#5-phase-1--work-items" >}})
-* [Open Issues]({{< ref "#open-issues" >}})
-* [Reference]({{< ref "#reference" >}})
+{{< toc >}}
 
 # Abstract
 

--- a/content/docs/latest/csv-serde_48202659.md
+++ b/content/docs/latest/csv-serde_48202659.md
@@ -5,10 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : CSV Serde
 
-* [Availability]({{< ref "#availability" >}})
-* [Background]({{< ref "#background" >}})
-* [Usage]({{< ref "#usage" >}})
-* [Versions]({{< ref "#versions" >}})
+{{< toc >}}
 
 ### Availability
 

--- a/content/docs/latest/datasketches-integration_177050456.md
+++ b/content/docs/latest/datasketches-integration_177050456.md
@@ -5,23 +5,10 @@ date: 2024-12-12
 
 # Apache Hive : Datasketches Integration
 
-* [Sketch functions]({{< ref "#sketch-functions" >}})
-	+ [Naming convention]({{< ref "#naming-convention" >}})
-	+ [List declared sketch functions]({{< ref "#list-declared-sketch-functions" >}})
-* [Integration with materialized views]({{< ref "#integration-with-materialized-views" >}})
-* [BI mode]({{< ref "#bi-mode" >}})
-	+ [Rewrite COUNT(DISTINCT(X))]({{< ref "#rewrite-countdistinctx" >}})
-	+ [Rewrite percentile_disc(p) withing group(order by x)]({{< ref "#rewrite-percentile_discp-withing-grouporder-by-x" >}})
-	+ [Rewrite cume_dist() over (order by id)]({{< ref "#rewrite-cume_dist---over--order-by-id-" >}})
-	+ [Rewrite NTILE]({{< ref "#rewrite-ntile" >}})
-	+ [Rewrite RANK]({{< ref "#rewrite-rank" >}})
-* [Examples]({{< ref "#examples" >}})
-	+ [Simple distinct counting examples using HLL]({{< ref "#simple-distinct-counting-examples-using-hll" >}})
-
-  
-
 Apache DataSketches (<https://datasketches.apache.org/>) is integrated into Hive via [HIVE-22939](https://issues.apache.org/jira/browse/HIVE-22939).  
 This enables various kind of sketch operations thru regular sql statement.
+
+{{< toc >}}
 
 # Sketch functions
 

--- a/content/docs/latest/design_27362072.md
+++ b/content/docs/latest/design_27362072.md
@@ -7,22 +7,12 @@ date: 2024-12-12
 
 This page contains details about the Hive design and architecture. A brief technical report about Hive is available at [hive.pdf]({{< ref "#hive-pdf" >}}).
 
-* [Hive Architecture]({{< ref "#hive-architecture" >}})
-* [Hive Data Model]({{< ref "#hive-data-model" >}})
-* [Metastore]({{< ref "#metastore" >}})
-	+ [Motivation]({{< ref "#motivation" >}})
-	+ [Metadata Objects]({{< ref "#metadata-objects" >}})
-	+ [Metastore Architecture]({{< ref "#metastore-architecture" >}})
-	+ [Metastore Interface]({{< ref "#metastore-interface" >}})
-* [Hive Query Language]({{< ref "#hive-query-language" >}})
-* [Compiler]({{< ref "#compiler" >}})
-* [Optimizer]({{< ref "#optimizer" >}})
-* [Hive APIs]({{< ref "#hive-apis" >}})
-
-Figure 1  
- ![](/attachments/27362072/47743299.png)
+{{< toc >}}
 
 ## Hive Architecture
+
+Figure 1  
+![](/attachments/27362072/47743299.png)
 
 Figure 1 shows the major components of Hive and its interactions with Hadoop. As shown in that figure, the main components of Hive are:
 

--- a/content/docs/latest/developerguide-udtf_27362086.md
+++ b/content/docs/latest/developerguide-udtf_27362086.md
@@ -5,11 +5,6 @@ date: 2024-12-12
 
 # Apache Hive : DeveloperGuide UDTF
 
-# Writing UDTF's
-
-* [Writing UDTF's]({{< ref "#writing-udtfs" >}})
-	+ [GenericUDTF Interface]({{< ref "#genericudtf-interface" >}})
-
 ## GenericUDTF Interface
 
 A custom UDTF can be created by extending the GenericUDTF abstract class and then implementing the `initialize`, `process`, and possibly `close` methods. The `initialize` method is called by Hive to notify the UDTF the argument types to expect. The UDTF must then return an object inspector corresponding to the row objects that the UDTF will generate. Once `initialize()` has been called, Hive will give rows to the UDTF using the `process()` method. While in `process()`, the UDTF can produce and forward rows to other operators by calling `forward()`. Lastly, Hive will call the `close()` method when all the rows have passed to the UDTF.

--- a/content/docs/latest/druid-integration_65866491.md
+++ b/content/docs/latest/druid-integration_65866491.md
@@ -5,34 +5,9 @@ date: 2024-12-12
 
 # Apache Hive : Druid Integration
 
-* [Introduction]({{< ref "#introduction" >}})
-	+ [Objectives]({{< ref "#objectives" >}})
-* [Preliminaries]({{< ref "#preliminaries" >}})
-	+ [Druid]({{< ref "#druid" >}})
-	+ [Storage Handlers]({{< ref "#storage-handlers" >}})
-* [Usage]({{< ref "#usage" >}})
-	+ [Discovery and management of Druid datasources from Hive]({{< ref "#discovery-and-management-of-druid-datasources-from-hive" >}})
-		- [Create tables linked to existing Druid datasources]({{< ref "#create-tables-linked-to-existing-druid-datasources" >}})
-		- [Create Druid datasources from Hive]({{< ref "#create-druid-datasources-from-hive" >}})
-		- [Druid kafka ingestion from Hive]({{< ref "#druid-kafka-ingestion-from-hive" >}})
-			* [Start/Stop/Reset Druid Kafka ingestion]({{< ref "#startstopreset-druid-kafka-ingestion" >}})
-		- [INSERT, INSERT OVERWRITE and DROP statements]({{< ref "#insert-insert-overwrite-and-drop-statements" >}})
-		- [Queries completely executed in Druid]({{< ref "#queries-completely-executed-in-druid" >}})
-			* [Select queries]({{< ref "#select-queries" >}})
-			* [Timeseries queries]({{< ref "#timeseries-queries" >}})
-			* [GroupBy queries]({{< ref "#groupby-queries" >}})
-		- [Queries across Druid and Hive]({{< ref "#queries-across-druid-and-hive" >}})
-* [Open Issues (JIRA)]({{< ref "#open-issues-jira" >}})
+This page documents the work done for the integration between Druid and Hive introduced in Hive 2.2.0 ([HIVE-14217](https://issues.apache.org/jira/browse/HIVE-14217)). Initially it was compatible with Druid 0.9.1.1, the latest stable release of Druid to that date.
 
- 
-
-Version information
-
-Druid integration is introduced in Hive 2.2.0 ([HIVE-14217](https://issues.apache.org/jira/browse/HIVE-14217)). Initially it was compatible with Druid 0.9.1.1, the latest stable release of Druid to that date.
-
-# Introduction
-
-This page documents the work done for the integration between Druid and Hive, which was started in [HIVE-14217](https://issues.apache.org/jira/browse/HIVE-14217).
+{{< toc >}}
 
 ## Objectives
 

--- a/content/docs/latest/dynamicpartitions_27823715.md
+++ b/content/docs/latest/dynamicpartitions_27823715.md
@@ -5,14 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : DynamicPartitions
 
-# Dynamic Partitions
-
-* [Dynamic Partitions]({{< ref "#dynamic-partitions" >}})
-	+ [Documentation]({{< ref "#documentation" >}})
-	+ [Terminology]({{< ref "#terminology" >}})
-	+ [Syntax]({{< ref "#syntax" >}})
-	+ [Design]({{< ref "#design" >}})
-	+ [Design issues]({{< ref "#design-issues" >}})
+{{< toc >}}
 
 ## Documentation
 

--- a/content/docs/latest/filterpushdowndev_27362092.md
+++ b/content/docs/latest/filterpushdowndev_27362092.md
@@ -3,23 +3,11 @@ title: "Apache Hive : FilterPushdownDev"
 date: 2024-12-12
 ---
 
-# Apache Hive : FilterPushdownDev
-
-# Filter Pushdown
-
-* [Filter Pushdown]({{< ref "#filter-pushdown" >}})
-	+ [Introduction]({{< ref "#introduction" >}})
-	+ [Use Cases]({{< ref "#use-cases" >}})
-	+ [Components Involved]({{< ref "#components-involved" >}})
-	+ [Primary Filter Representation]({{< ref "#primary-filter-representation" >}})
-	+ [Other Filter Representations]({{< ref "#other-filter-representations" >}})
-	+ [Filter Passing]({{< ref "#filter-passing" >}})
-	+ [Filter Collection]({{< ref "#filter-collection" >}})
-	+ [Filter Decomposition]({{< ref "#filter-decomposition" >}})
-
-## Introduction
+# Apache Hive : Filter Pushdown
 
 This document explains how we are planning to add support in Hive's optimizer for pushing filters down into physical access methods. This is an important optimization for minimizing the amount of data scanned and processed by an access method (e.g. for an indexed key lookup), as well as reducing the amount of data passed into Hive for further query evaluation.
+
+{{< toc >}}
 
 ## Use Cases
 

--- a/content/docs/latest/genericudafcasestudy_27362093.md
+++ b/content/docs/latest/genericudafcasestudy_27362093.md
@@ -3,9 +3,7 @@ title: "Apache Hive : GenericUDAFCaseStudy"
 date: 2024-12-12
 ---
 
-# Apache Hive : GenericUDAFCaseStudy
-
-# Writing GenericUDAFs: A Tutorial
+# Apache Hive : Tutorial to write a GenericUDAF
 
 User-Defined Aggregation Functions (UDAFs) are an excellent way to integrate advanced data-processing into Hive. Hive allows two varieties of UDAFs: simple and generic. Simple UDAFs, as the name implies, are rather simple to write, but incur performance penalties because of the use of [Java Reflection](http://java.sun.com/docs/books/tutorial/reflect/index.html), and do not allow features such as variable-length argument lists. Generic UDAFs allow all these features, but are perhaps not quite as intuitive to write as Simple UDAFs.
 
@@ -13,23 +11,7 @@ This tutorial walks through the development of the `histogram()` UDAF, which com
 
 **NOTE:** In this tutorial, we walk through the creation of a `histogram()` function. Starting with the 0.6.0 release of Hive, this appears as the built-in function `histogram_numeric()`.
 
-* [Writing GenericUDAFs: A Tutorial]({{< ref "#writing-genericudafs-a-tutorial" >}})
-	+ [Preliminaries]({{< ref "#preliminaries" >}})
-	+ [Writing the source]({{< ref "#writing-the-source" >}})
-		- [Overview]({{< ref "#overview" >}})
-		- [Writing the resolver]({{< ref "#writing-the-resolver" >}})
-		- [Writing the evaluator]({{< ref "#writing-the-evaluator" >}})
-			* [getNewAggregationBuffer]({{< ref "#getnewaggregationbuffer" >}})
-			* [iterate]({{< ref "#iterate" >}})
-			* [terminatePartial]({{< ref "#terminatepartial" >}})
-			* [merge]({{< ref "#merge" >}})
-			* [terminate]({{< ref "#terminate" >}})
-	+ [Modifying the function registry]({{< ref "#modifying-the-function-registry" >}})
-	+ [Compiling and running]({{< ref "#compiling-and-running" >}})
-	+ [Creating the tests]({{< ref "#creating-the-tests" >}})
-* [Checklist for open source submission]({{< ref "#checklist-for-open-source-submission" >}})
-* [Tips, Tricks, Best Practices]({{< ref "#tips-tricks-best-practices" >}})
-	+ [Resolver Interface Evolution]({{< ref "#resolver-interface-evolution" >}})
+{{< toc >}}
 
 ## Preliminaries
 

--- a/content/docs/latest/gettingstarted_27362090.md
+++ b/content/docs/latest/gettingstarted_27362090.md
@@ -5,45 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : GettingStarted
 
-Table of Contents
-
-* [Installation and Configuration]({{< ref "#installation-and-configuration" >}})
-	
-		- [Running HiveServer2 and Beeline]({{< ref "#running-hiveserver2-and-beeline" >}})+ [Requirements]({{< ref "#requirements" >}})
-	+ [Installing Hive from a Stable Release]({{< ref "#installing-hive-from-a-stable-release" >}})
-	+ [Building Hive from Source]({{< ref "#building-hive-from-source" >}})
-		- [Compile Hive on master]({{< ref "#compile-hive-on-master" >}})
-		- [Compile Hive on branch-1]({{< ref "#compile-hive-on-branch-1" >}})
-		- [Compile Hive Prior to 0.13 on Hadoop 0.20]({{< ref "#compile-hive-prior-to-013-on-hadoop-020" >}})
-		- [Compile Hive Prior to 0.13 on Hadoop 0.23]({{< ref "#compile-hive-prior-to-013-on-hadoop-023" >}})
-	+ [Running Hive]({{< ref "#running-hive" >}})
-		- [Running Hive CLI]({{< ref "#running-hive-cli" >}})
-		- [Running HiveServer2 and Beeline]({{< ref "#running-hiveserver2-and-beeline" >}})
-		- [Running HCatalog]({{< ref "#running-hcatalog" >}})
-		- [Running WebHCat (Templeton)]({{< ref "#running-webhcat-templeton" >}})
-	+ [Configuration Management Overview]({{< ref "#configuration-management-overview" >}})
-	+ [Runtime Configuration]({{< ref "#runtime-configuration" >}})
-	+ [Hive, Map-Reduce and Local-Mode]({{< ref "#hive-map-reduce-and-local-mode" >}})
-	+ [Hive Logging]({{< ref "#hive-logging" >}})
-		- [HiveServer2 Logs]({{< ref "#hiveserver2-logs" >}})
-		- [Audit Logs]({{< ref "#audit-logs" >}})
-		- [Perf Logger]({{< ref "#perf-logger" >}})
-* [DDL Operations]({{< ref "#ddl-operations" >}})
-	+ [Creating Hive Tables]({{< ref "#creating-hive-tables" >}})
-	+ [Browsing through Tables]({{< ref "#browsing-through-tables" >}})
-	+ [Altering and Dropping Tables]({{< ref "#altering-and-dropping-tables" >}})
-	+ [Metadata Store]({{< ref "#metadata-store" >}})
-* [DML Operations]({{< ref "#dml-operations" >}})
-* [SQL Operations]({{< ref "#sql-operations" >}})
-	+ [Example Queries]({{< ref "#example-queries" >}})
-		- [SELECTS and FILTERS]({{< ref "#selects-and-filters" >}})
-		- [GROUP BY]({{< ref "#group-by" >}})
-		- [JOIN]({{< ref "#join" >}})
-		- [MULTITABLE INSERT]({{< ref "#multitable-insert" >}})
-		- [STREAMING]({{< ref "#streaming" >}})
-* [Simple Example Use Cases]({{< ref "#simple-example-use-cases" >}})
-	+ [MovieLens User Ratings]({{< ref "#movielens-user-ratings" >}})
-	+ [Apache Weblog Data]({{< ref "#apache-weblog-data" >}})
+{{< toc >}}
 
 ## Installation and Configuration
 

--- a/content/docs/latest/groupbywithrollup_27826238.md
+++ b/content/docs/latest/groupbywithrollup_27826238.md
@@ -3,25 +3,9 @@ title: "Apache Hive : GroupByWithRollup"
 date: 2024-12-12
 ---
 
-# Apache Hive : GroupByWithRollup
+# Apache Hive : Group By With Rollup
 
-# Group By With Rollup
-
-References:   
-
-[Original design doc](https://issues.apache.org/jira/secure/attachment/12437909/dp_design.txt)   
-
-[HIVE-2397](https://issues.apache.org/jira/browse/HIVE-2397) 
-
-* [Group By With Rollup]({{< ref "#group-by-with-rollup" >}})
-	+ [Terminology]({{< ref "#terminology" >}})
-	+ [Design]({{< ref "#design" >}})
-		- [Map Aggr & No Skew:]({{< ref "#map-aggr--no-skew" >}})
-		- [Map Aggr & Skew]({{< ref "#map-aggr--skew" >}})
-		- [No Map Aggr & No Skew & No Rollup]({{< ref "#no-map-aggr--no-skew--no-rollup" >}})
-		- [No Map Aggr & No Skew & With Rollup]({{< ref "#no-map-aggr--no-skew--with-rollup" >}})
-		- [No Map Aggr & Skew & (No Distinct or No Rollup)]({{< ref "#no-map-aggr--skew--no-distinct-or-no-rollup" >}})
-		- [No Map Aggr & Skew & Distinct & Rollup]({{< ref "#no-map-aggr--skew--distinct--rollup" >}})
+{{< toc >}}
 
 ## Terminology
 
@@ -152,7 +136,7 @@ Reducer 3:
 
 Note that if there are no group by keys or distinct keys, Reducer 2 and Mapper 3 are removed from the plan and the reduce sink operator in Mapper 2 does not spray. Also, note that the reason for Mapper 2 spraying is that if the skew in the data existed in a column that is not immediately nulled by the rollup (e.g. if we the group by keys are columns g1, g2, g3 in that order, we are concerned with the case where the skew exists in column g1 or g2) the skew may continue to exist after the hash aggregation, so we spray.
 
- 
+## References
 
- 
-
+* [Original design doc](https://issues.apache.org/jira/secure/attachment/12437909/dp_design.txt)
+* [HIVE-2397](https://issues.apache.org/jira/browse/HIVE-2397)

--- a/content/docs/latest/hbasebulkload_27362088.md
+++ b/content/docs/latest/hbasebulkload_27362088.md
@@ -3,23 +3,11 @@ title: "Apache Hive : HBaseBulkLoad"
 date: 2024-12-12
 ---
 
-# Apache Hive : HBaseBulkLoad
-
-# Hive HBase Bulk Load
-
-* [Hive HBase Bulk Load]({{< ref "#hive-hbase-bulk-load" >}})
-	+ [Overview]({{< ref "#overview" >}})
-	+ [Decide on Target HBase Schema]({{< ref "#decide-on-target-hbase-schema" >}})
-	+ [Estimate Resources Needed]({{< ref "#estimate-resources-needed" >}})
-	+ [Add necessary JARs]({{< ref "#add-necessary-jars" >}})
-	+ [Prepare Range Partitioning]({{< ref "#prepare-range-partitioning" >}})
-	+ [Prepare Staging Location]({{< ref "#prepare-staging-location" >}})
-	+ [Sort Data]({{< ref "#sort-data" >}})
-	+ [Run HBase Script]({{< ref "#run-hbase-script" >}})
-	+ [Map New Table Back Into Hive]({{< ref "#map-new-table-back-into-hive" >}})
-	+ [Followups Needed]({{< ref "#followups-needed" >}})
+# Apache Hive : HBase Bulk Load
 
 This page explains how to use Hive to bulk load data into a new (empty) HBase table per [HIVE-1295](https://issues.apache.org/jira/browse/HIVE-1295). (If you're not using a build which contains this functionality yet, you'll need to build from source and make sure this patch and HIVE-1321 are both applied.)
+
+{{< toc >}}
 
 ## Overview
 

--- a/content/docs/latest/hbaseintegration_27362089.md
+++ b/content/docs/latest/hbaseintegration_27362089.md
@@ -3,36 +3,17 @@ title: "Apache Hive : HBaseIntegration"
 date: 2024-12-12
 ---
 
-# Apache Hive : HBaseIntegration
+# Apache Hive : HBase Integration
 
-# Hive HBase Integration
+This page documents the Hive/HBase integration support originally introduced in [HIVE-705](https://issues.apache.org/jira/browse/HIVE-705). This feature allows Hive QL statements to access [HBase](http://hadoop.apache.org/hbase) tables for both read (SELECT) and write (INSERT). It is even possible to combine access to HBase tables with native Hive tables via joins and unions.
 
-* [Hive HBase Integration]({{< ref "#hive-hbase-integration" >}})
-	
-		- [Avro Data Stored in HBase Columns]({{< ref "#avro-data-stored-in-hbase-columns" >}})+ [Introduction]({{< ref "#introduction" >}})
-	+ [Storage Handlers]({{< ref "#storage-handlers" >}})
-	+ [Usage]({{< ref "#usage" >}})
-	+ [Column Mapping]({{< ref "#column-mapping" >}})
-		- [Multiple Columns and Families]({{< ref "#multiple-columns-and-families" >}})
-		- [Hive MAP to HBase Column Family]({{< ref "#hive-map-to-hbase-column-family" >}})
-		- [Hive MAP to HBase Column Prefix]({{< ref "#hive-map-to-hbase-column-prefix" >}})
-			* [Hiding Column Prefixes]({{< ref "#hiding-column-prefixes" >}})
-		- [Illegal: Hive Primitive to HBase Column Family]({{< ref "#illegal-hive-primitive-to-hbase-column-family" >}})
-		- [Example with Binary Columns]({{< ref "#example-with-binary-columns" >}})
-		- [Simple Composite Row Keys]({{< ref "#simple-composite-row-keys" >}})
-		- [Complex Composite Row Keys and HBaseKeyFactory]({{< ref "#complex-composite-row-keys-and-hbasekeyfactory" >}})
-		- [Avro Data Stored in HBase Columns]({{< ref "#avro-data-stored-in-hbase-columns" >}})
-	+ [Put Timestamps]({{< ref "#put-timestamps" >}})
-	+ [Key Uniqueness]({{< ref "#key-uniqueness" >}})
-	+ [Overwrite]({{< ref "#overwrite" >}})
-	+ [Potential Followups]({{< ref "#potential-followups" >}})
-	+ [Build]({{< ref "#build" >}})
-	+ [Tests]({{< ref "#tests" >}})
-	+ [Links]({{< ref "#links" >}})
-	+ [Acknowledgements]({{< ref "#acknowledgements" >}})
-	+ [Open Issues (JIRA)]({{< ref "#open-issues-jira" >}})
+A presentation is available from the [HBase HUG10 Meetup](http://wiki.apache.org/hadoop/Hive/Presentations?action=AttachFile&do=get&target=HiveHBase-HUG10.ppt)
 
-Version information
+This feature is a work in progress, and suggestions for its improvement are very welcome.
+
+{{< toc >}}
+
+## Version Information
 
 ### Avro Data Stored in HBase Columns
 
@@ -41,14 +22,6 @@ As of Hive 0.9.0 the HBase integration requires at least HBase 0.92, earlier ver
 Version information
 
 Hive 1.x will remain compatible with HBase 0.98.x and lower versions. Hive 2.x will be compatible with HBase 1.x and higher. (See [HIVE-10990](https://issues.apache.org/jira/browse/HIVE-10990) for details.) Consumers wanting to work with HBase 1.x using Hive 1.x will need to compile Hive 1.x stream code themselves.
-
-## Introduction
-
-This page documents the Hive/HBase integration support originally introduced in [HIVE-705](https://issues.apache.org/jira/browse/HIVE-705). This feature allows Hive QL statements to access [HBase](http://hadoop.apache.org/hbase) tables for both read (SELECT) and write (INSERT). It is even possible to combine access to HBase tables with native Hive tables via joins and unions.
-
-A presentation is available from the [HBase HUG10 Meetup](http://wiki.apache.org/hadoop/Hive/Presentations?action=AttachFile&do=get&target=HiveHBase-HUG10.ppt)
-
-This feature is a work in progress, and suggestions for its improvement are very welcome.
 
 ## Storage Handlers
 

--- a/content/docs/latest/hbasemetastoredevelopmentguide_55151960.md
+++ b/content/docs/latest/hbasemetastoredevelopmentguide_55151960.md
@@ -11,12 +11,7 @@ Guide for contributors to the metastore on hbase development work. Umbrella JIR
 
 This work is discontinued and the code is removed in release 3.0.0 ([HIVE-17234](https://issues.apache.org/jira/browse/HIVE-17234)).
 
- 
-
-* [Building]({{< ref "#building" >}})
-* [Setup for running hive against hbase metastore -]({{< ref "#setup-for-running-hive-against-hbase-metastore--" >}})
-* [Importing metadata from rdbms to hbase]({{< ref "#importing-metadata-from-rdbms-to-hbase" >}})
-* [Design Docs]({{< ref "#design-docs" >}})
+{{< toc >}}
 
 # Building
 

--- a/content/docs/latest/hcatalog-authorization_34014782.md
+++ b/content/docs/latest/hcatalog-authorization_34014782.md
@@ -5,16 +5,9 @@ date: 2024-12-12
 
 # Apache Hive : HCatalog Authorization
 
-# Storage Based Authorization
+{{< toc >}}
 
-* [Storage Based Authorization]({{< ref "#storage-based-authorization" >}})
-	+ [Default Authorization Model of Hive]({{< ref "#default-authorization-model-of-hive" >}})
-	+ [Storage-System Based Authorization Model]({{< ref "#storage-system-based-authorization-model" >}})
-		- [Minimum Permissions]({{< ref "#minimum-permissions" >}})
-		- [Unused DDL for Permissions]({{< ref "#unused-ddl-for-permissions" >}})
-	+ [Configuring Storage-System Based Authorization]({{< ref "#configuring-storage-system-based-authorization" >}})
-	+ [Creating New Tables or Databases]({{< ref "#creating-new-tables-or-databases" >}})
-	+ [Known Issues]({{< ref "#known-issues" >}})
+# Storage Based Authorization
 
 ## Default Authorization Model of Hive
 

--- a/content/docs/latest/hcatalog-cli_34013932.md
+++ b/content/docs/latest/hcatalog-cli_34013932.md
@@ -3,26 +3,9 @@ title: "Apache Hive : HCatalog CLI"
 date: 2024-12-12
 ---
 
-# Apache Hive : HCatalog CLI
+# Apache Hive : HCatalog Command Line Interface
 
-# Command Line Interface
-
-* [Command Line Interface]({{< ref "#command-line-interface" >}})
-	+ [Set Up]({{< ref "#set-up" >}})
-	+ [HCatalog CLI]({{< ref "#hcatalog-cli" >}})
-		- [Owner Permissions]({{< ref "#owner-permissions" >}})
-		- [Hive CLI]({{< ref "#hive-cli" >}})
-	+ [HCatalog DDL]({{< ref "#hcatalog-ddl" >}})
-		- [Create/Drop/Alter Table]({{< ref "#createdropalter-table" >}})
-		- [Create/Drop/Alter View]({{< ref "#createdropalter-view" >}})
-		- [Show/Describe]({{< ref "#showdescribe" >}})
-		- [Create/Drop Index]({{< ref "#createdrop-index" >}})
-		- [Create/Drop Function]({{< ref "#createdrop-function" >}})
-		- ["dfs" Command and "set" Command]({{< ref "#dfs-set-cmd" >}})
-		- [Other Commands]({{< ref "#other-commands" >}})
-	+ [CLI Errors]({{< ref "#cli-errors" >}})
-		- [Authentication]({{< ref "#authentication" >}})
-		- [Error Log]({{< ref "#error-log" >}})
+{{< toc >}}
 
 ## Set Up
 

--- a/content/docs/latest/hcatalog-configuration-properties_39622369.md
+++ b/content/docs/latest/hcatalog-configuration-properties_39622369.md
@@ -5,14 +5,9 @@ date: 2024-12-12
 
 # Apache Hive : HCatalog Configuration Properties
 
-* [Setup]({{< ref "#setup" >}})
-* [Storage Directives]({{< ref "#storage-directives" >}})
-* [Cache Behaviour Directives]({{< ref "#cache-behaviour-directives" >}})
-* [Input Split Generation Behaviour]({{< ref "#input-split-generation-behaviour" >}})
-* [Data Promotion Behaviour]({{< ref "#data-promotion-behaviour" >}})
-* [HCatRecordReader Error Tolerance Behaviour]({{< ref "#hcatrecordreader-error-tolerance-behaviour" >}})
-
 Apache HCatalog's behaviour can be modified through the use of a few configuration parameters specified in jobs submitted to it. This document details all the various knobs that users have available to them, and what they accomplish. 
+
+{{< toc >}}
 
 ## Setup
 

--- a/content/docs/latest/hcatalog-dynamicpartitions_34014006.md
+++ b/content/docs/latest/hcatalog-dynamicpartitions_34014006.md
@@ -3,16 +3,9 @@ title: "Apache Hive : HCatalog DynamicPartitions"
 date: 2024-12-12
 ---
 
-# Apache Hive : HCatalog DynamicPartitions
+# Apache Hive : HCatalog Dynamic Partitioning
 
-# Dynamic Partitioning
-
-* [Dynamic Partitioning]({{< ref "#dynamic-partitioning" >}})
-	+ [Overview]({{< ref "#overview" >}})
-		- [External Tables]({{< ref "#external-tables" >}})
-		- [Hive Dynamic Partitions]({{< ref "#hive-dynamic-partitions" >}})
-	+ [Usage with Pig]({{< ref "#usage-with-pig" >}})
-	+ [Usage from MapReduce]({{< ref "#usage-from-mapreduce" >}})
+{{< toc >}}
 
 ## Overview
 

--- a/content/docs/latest/hcatalog-inputoutput_34013776.md
+++ b/content/docs/latest/hcatalog-inputoutput_34013776.md
@@ -3,23 +3,9 @@ title: "Apache Hive : HCatalog InputOutput"
 date: 2024-12-12
 ---
 
-# Apache Hive : HCatalog InputOutput
+# Apache Hive : HCatalog Input and Output Interfaces
 
-# Input and Output Interfaces
-
-* [Input and Output Interfaces]({{< ref "#input-and-output-interfaces" >}})
-	+ [Set Up]({{< ref "#set-up" >}})
-	+ [HCatInputFormat]({{< ref "#hcatinputformat" >}})
-		- [API]({{< ref "#api" >}})
-	+ [HCatOutputFormat]({{< ref "#hcatoutputformat" >}})
-		- [API]({{< ref "#api" >}})
-	+ [HCatRecord]({{< ref "#hcatrecord" >}})
-	+ [Running MapReduce with HCatalog]({{< ref "#running-mapreduce-with-hcatalog" >}})
-		- [Authentication]({{< ref "#authentication" >}})
-		- [Read Example]({{< ref "#read-example" >}})
-		- [Filter Operators]({{< ref "#filter-operators" >}})
-		- [Scan Filter]({{< ref "#scan-filter" >}})
-		- [Write Filter]({{< ref "#write-filter" >}})
+{{< toc >}}
 
 ## Set Up
 

--- a/content/docs/latest/hcatalog-installhcat_34013403.md
+++ b/content/docs/latest/hcatalog-installhcat_34013403.md
@@ -3,15 +3,9 @@ title: "Apache Hive : HCatalog InstallHCat"
 date: 2024-12-12
 ---
 
-# Apache Hive : HCatalog InstallHCat
+# Apache Hive : HCatalog Installation from Tarball
 
-# Installation from Tarball
-
-* [Installation from Tarball]({{< ref "#installation-from-tarball" >}})
-	+ [HCatalog Installed with Hive]({{< ref "#hcatalog-installed-with-hive" >}})
-	+ [HCatalog Command Line]({{< ref "#hcatalog-command-line" >}})
-	+ [HCatalog Client Jars]({{< ref "#hcatalog-client-jars" >}})
-	+ [HCatalog Server]({{< ref "#hcatalog-server" >}})
+{{< toc >}}
 
 ## HCatalog Installed with Hive
 

--- a/content/docs/latest/hcatalog-loadstore_34013511.md
+++ b/content/docs/latest/hcatalog-loadstore_34013511.md
@@ -3,35 +3,9 @@ title: "Apache Hive : HCatalog LoadStore"
 date: 2024-12-12
 ---
 
-# Apache Hive : HCatalog LoadStore
-
-# Load and Store Interfaces
-
-* [Load and Store Interfaces]({{< ref "#load-and-store-interfaces" >}})
-	+ [Set Up]({{< ref "#set-up" >}})
-	+ [Running Pig]({{< ref "#running-pig" >}})
-	+ [HCatLoader]({{< ref "#hcatloader" >}})
-		- [Usage]({{< ref "#usage" >}})
-			* [Assumptions]({{< ref "#assumptions" >}})
-		- [HCatLoader Data Types]({{< ref "#hcatloader-data-types" >}})
-			* [Types in Hive 0.12.0 and Earlier]({{< ref "#types-in-hive-0120-and-earlier" >}})
-			* [Types in Hive 0.13.0 and Later]({{< ref "#types-in-hive-0130-and-later" >}})
-		- [Running Pig with HCatalog]({{< ref "#running-pig-with-hcatalog" >}})
-			* [The -useHCatalog Flag]({{< ref "#the--usehcatalog-flag" >}})
-			* [Jars and Configuration Files]({{< ref "#jars-and-configuration-files" >}})
-			* [Authentication]({{< ref "#authentication" >}})
-		- [Load Examples]({{< ref "#load-examples" >}})
-			* [Filter Operators]({{< ref "#filter-operators" >}})
-	+ [HCatStorer]({{< ref "#hcatstorer" >}})
-		- [Usage]({{< ref "#usage" >}})
-			* [Assumptions]({{< ref "#assumptions" >}})
-		- [Store Examples]({{< ref "#store-examples" >}})
-		- [HCatStorer Data Types]({{< ref "#hcatstorer-data-types" >}})
-			* [Types in Hive 0.12.0 and Earlier]({{< ref "#types-in-hive-0120-and-earlier" >}})
-			* [Types in Hive 0.13.0 and Later]({{< ref "#types-in-hive-0130-and-later" >}})
-	+ [Data Type Mappings]({{< ref "#data-type-mappings" >}})
-		- [Primitive Types]({{< ref "#primitive-types" >}})
-		- [Complex Types]({{< ref "#complex-types" >}})
+# Apache Hive : HCatalog Load and Store Interfaces
+ 
+{{< toc >}}
 
 ## Set Up
 

--- a/content/docs/latest/hcatalog-notification_34014558.md
+++ b/content/docs/latest/hcatalog-notification_34014558.md
@@ -5,14 +5,9 @@ date: 2024-12-12
 
 # Apache Hive : HCatalog Notification
 
-# Notification
+{{< toc >}}
 
-* [Notification]({{< ref "#notification" >}})
-	+ [Notification for a New Partition]({{< ref "#notification-for-a-new-partition" >}})
-	+ [Notification for a Set of Partitions]({{< ref "#notification-for-a-set-of-partitions" >}})
-	+ [Server Configuration]({{< ref "#server-configuration" >}})
-		- [Enable JMS Notifications]({{< ref "#enable-jms-notifications" >}})
-		- [Topic Names]({{< ref "#topic-names" >}})
+## Overview
 
 Since version 0.2, HCatalog provides notifications for certain events happening in the system. This way applications such as Oozie can wait for those events and schedule the work that depends on them. The current version of HCatalog supports two kinds of events:
 

--- a/content/docs/latest/hcatalog-readerwriter_34013921.md
+++ b/content/docs/latest/hcatalog-readerwriter_34013921.md
@@ -3,15 +3,9 @@ title: "Apache Hive : HCatalog ReaderWriter"
 date: 2024-12-12
 ---
 
-# Apache Hive : HCatalog ReaderWriter
+# Apache Hive : HCatalog Reader and Writer Interfaces
 
-# Reader and Writer Interfaces
-
-* [Reader and Writer Interfaces]({{< ref "#reader-and-writer-interfaces" >}})
-	+ [Overview]({{< ref "#overview" >}})
-	+ [HCatReader]({{< ref "#hcatreader" >}})
-	+ [HCatWriter]({{< ref "#hcatwriter" >}})
-	+ [Complete Example Program]({{< ref "#complete-example-program" >}})
+{{< toc >}}
 
 ## Overview
 

--- a/content/docs/latest/hcatalog-storageformats_34013997.md
+++ b/content/docs/latest/hcatalog-storageformats_34013997.md
@@ -3,14 +3,9 @@ title: "Apache Hive : HCatalog StorageFormats"
 date: 2024-12-12
 ---
 
-# Apache Hive : HCatalog StorageFormats
+# Apache Hive : HCatalog Storage Formats
 
-# Storage Formats
-
-* [Storage Formats]({{< ref "#storage-formats" >}})
-	+ [SerDes and Storage Formats]({{< ref "#serdes-and-storage-formats" >}})
-	+ [Usage from Hive]({{< ref "#usage-from-hive" >}})
-	+ [CTAS Issue with JSON SerDe]({{< ref "#ctas-issue-with-json-serde" >}})
+{{< toc >}}
 
 ### SerDes and Storage Formats
 

--- a/content/docs/latest/hcatalog-streaming-mutation-api_61337025.md
+++ b/content/docs/latest/hcatalog-streaming-mutation-api_61337025.md
@@ -7,16 +7,7 @@ date: 2024-12-12
 
 A Java API focused on mutating (insert/update/delete) records into transactional tables using Hive’s [ACID](https://cwiki.apache.org/confluence/display/Hive/Hive+Transactions) feature. It is introduced in Hive 2.0.0 ([HIVE-10165](https://issues.apache.org/jira/browse/HIVE-10165)).
 
-* [Background]({{< ref "#background" >}})
-* [Structure]({{< ref "#structure" >}})
-* [Data Requirements]({{< ref "#data-requirements" >}})
-* [Streaming Requirements]({{< ref "#streaming-requirements" >}})
-* [Record Layout]({{< ref "#record-layout" >}})
-* [Connection and Transaction Management]({{< ref "#connection-and-transaction-management" >}})
-* [Writing Data]({{< ref "#writing-data" >}})
-	+ [Dynamic Partition Creation]({{< ref "#dynamic-partition-creation" >}})
-* [Reading Data]({{< ref "#reading-data" >}})
-* [Example]({{< ref "#example" >}})
+{{< toc >}}
 
 # Background
 

--- a/content/docs/latest/hcatalog-usinghcat_34013260.md
+++ b/content/docs/latest/hcatalog-usinghcat_34013260.md
@@ -3,22 +3,11 @@ title: "Apache Hive : HCatalog UsingHCat"
 date: 2024-12-12
 ---
 
-# Apache Hive : HCatalog UsingHCat
+# Apache Hive : HCatalog Usage
 
-# Using HCatalog
+{{< toc >}}
 
-* [Using HCatalog]({{< ref "#using-hcatalog" >}})
-	+ [Overview]({{< ref "#overview" >}})
-	+ [HCatalog Architecture]({{< ref "#hcatalog-architecture" >}})
-		- [Interfaces]({{< ref "#interfaces" >}})
-		- [Data Model]({{< ref "#data-model" >}})
-	+ [Data Flow Example]({{< ref "#data-flow-example" >}})
-		- [First: Copy Data to the Grid]({{< ref "#first-copy-data-to-the-grid" >}})
-		- [Second: Prepare the Data]({{< ref "#second-prepare-the-data" >}})
-		- [Third: Analyze the Data]({{< ref "#third-analyze-the-data" >}})
-	+ [HCatalog Web API]({{< ref "#hcatalog-web-api" >}})
-
-Version information
+## Version information
 
 HCatalog graduated from the Apache incubator and merged with the Hive project on March 26, 2013.  
  Hive version 0.11.0 is the first release that includes HCatalog.

--- a/content/docs/latest/hive-apis-overview_61326349.md
+++ b/content/docs/latest/hive-apis-overview_61326349.md
@@ -5,22 +5,9 @@ date: 2024-12-12
 
 # Apache Hive : Hive APIs Overview
 
-  
-
 This page aims to catalogue and describe the various public facing APIs exposed by Hive in order to inform developers wishing to integrate their applications and frameworks with the Hive ecosystem. To date the following APIs have been identified in the Hive project that are either considered public, or widely used in the public domain:
 
-* [API categories]({{< ref "#api-categories" >}})
-	+ [Operation based APIs]({{< ref "#operation-based-apis" >}})
-	+ [Query based APIs]({{< ref "#query-based-apis" >}})
-* [Available APIs]({{< ref "#available-apis" >}})
-	+ [HCatClient (Java)]({{< ref "#hcatclient-java" >}})
-	+ [HCatalog Storage Handlers (Java)]({{< ref "#hcatalog-storage-handlers-java" >}})
-	+ [HCatalog CLI (Command Line)]({{< ref "#hcatalog-cli-command-line" >}})
-	+ [Metastore (Java)]({{< ref "#metastore-java" >}})
-	+ [WebHCat (REST)]({{< ref "#webhcat-rest" >}})
-	+ [Streaming Data Ingest (Java)]({{< ref "#streaming-data-ingest-java" >}})
-	+ [Streaming Mutation (Java)]({{< ref "#streaming-mutation-java" >}})
-	+ [hive-jdbc (JDBC)]({{< ref "#hive-jdbc-jdbc" >}})
+{{< toc >}}
 
 # API categories
 

--- a/content/docs/latest/hive-metatool_55156221.md
+++ b/content/docs/latest/hive-metatool_55156221.md
@@ -5,14 +5,6 @@ date: 2024-12-12
 
 # Apache Hive : Hive MetaTool
 
-* [Hive MetaTool]({{< ref "#hive-metatool" >}})
-	+ [The metatool Command]({{< ref "#the-metatool-command" >}})
-	+ [Usage Example]({{< ref "#usage-example" >}})
-
-## Hive MetaTool
-
-Version 0.10.0 and later
-
 Introduced in Hive 0.10.0. See [HIVE-3056](https://issues.apache.org/jira/browse/HIVE-3056) and [HIVE-3443](https://issues.apache.org/jira/browse/HIVE-3443).
 
 The Hive MetaTool enables administrators to do bulk updates on the location fields in database, table, and partition records in the metastore.  It provides the following functionality:

--- a/content/docs/latest/hive-on-spark_42567714.md
+++ b/content/docs/latest/hive-on-spark_42567714.md
@@ -5,38 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : Hive on Spark
 
-* [1. Introduction]({{< ref "#1-introduction" >}})
-	+ [1.1 Motivation]({{< ref "#11-motivation" >}})
-	+ [1.2 Design Principle]({{< ref "#12-design-principle" >}})
-	+ [1.3 Comparison with Shark and Spark SQL]({{< ref "#13-comparison-with-shark-and-spark-sql" >}})
-	+ [1.4 Other Considerations]({{< ref "#14-other-considerations" >}})
-* [2. High-Level Functionality]({{< ref "#2-high-level-functionality" >}})
-	+ [2.1 A New Execution Engine]({{< ref "#21-a-new-execution-engine" >}})
-	+ [2.2 Spark Configuration]({{< ref "#22-spark-configuration" >}})
-	+ [2.3 Miscellaneous Functionality]({{< ref "#23-miscellaneous-functionality" >}})
-* [3. Hive-Level Design]({{< ref "#3-hive-level-design" >}})
-	+ [3.1 Query Planning]({{< ref "#31-query-planning" >}})
-	+ [3.2 Job Execution]({{< ref "#32-job-execution" >}})
-	+ [3.3 Design Considerations]({{< ref "#33-design-considerations" >}})
-		- [Table as RDD]({{< ref "#table-as-rdd" >}})
-		- [SparkWork]({{< ref "#sparkwork" >}})
-		- [SparkTask]({{< ref "#sparktask" >}})
-		- [Shuffle, Group, and Sort]({{< ref "#shuffle-group-and-sort" >}})
-		- [Join]({{< ref "#join" >}})
-		- [Number of Tasks]({{< ref "#number-of-tasks" >}})
-		- [Local MapReduce Tasks]({{< ref "#local-mapreduce-tasks" >}})
-		- [Semantic Analysis and Logical Optimizations]({{< ref "#semantic-analysis-and-logical-optimizations" >}})
-		- [Job Diagnostics]({{< ref "#job-diagnostics" >}})
-		- [Counters and Metrics]({{< ref "#counters-and-metrics" >}})
-		- [Explain Statements]({{< ref "#explain-statements" >}})
-		- [Hive Variables]({{< ref "#hive-variables" >}})
-		- [Union]({{< ref "#union" >}})
-		- [Concurrency and Thread Safety]({{< ref "#concurrency-and-thread-safety" >}})
-		- [Build Infrastructure]({{< ref "#build-infrastructure" >}})
-		- [Mini Spark Cluster]({{< ref "#mini-spark-cluster" >}})
-		- [Testing]({{< ref "#testing" >}})
-	+ [3.4 Potentially Required Work from Spark]({{< ref "#34-potentially-required-work-from-spark" >}})
-* [4. Summary]({{< ref "#4-summary" >}})
+{{< toc >}}
 
 # 1. Introduction
 

--- a/content/docs/latest/hive-on-tez_33296197.md
+++ b/content/docs/latest/hive-on-tez_33296197.md
@@ -5,39 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : Hive on Tez
 
-* [Overview]({{< ref "#overview" >}})
-	+ [Multiple reduce stages]({{< ref "#multiple-reduce-stages" >}})
-	+ [Pipelining]({{< ref "#pipelining" >}})
-	+ [In memory versus disk writes]({{< ref "#in-memory-versus-disk-writes" >}})
-	+ [Joins]({{< ref "#joins" >}})
-	+ [Fine-tuned algorithms]({{< ref "#fine-tuned-algorithms" >}})
-	+ [Limit processing]({{< ref "#limit-processing" >}})
-* [Scope]({{< ref "#scope" >}})
-* [Functional requirements of phase I]({{< ref "#functional-requirements-of-phase-i" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Plan with TEZ]({{< ref "#plan-with-tez" >}})
-		- [Plan without TEZ]({{< ref "#plan-without-tez" >}})
-* [Design]({{< ref "#design" >}})
-	+ [Summary of changes]({{< ref "#summary-of-changes" >}})
-	+ [Execution layer]({{< ref "#execution-layer" >}})
-		- [Job submission]({{< ref "#job-submission" >}})
-		- [Job monitoring]({{< ref "#job-monitoring" >}})
-		- [Job diagnostics]({{< ref "#job-diagnostics" >}})
-		- [Counters]({{< ref "#counters" >}})
-		- [Job execution]({{< ref "#job-execution" >}})
-	+ [Query planning]({{< ref "#query-planning" >}})
-		- [MapRedWork]({{< ref "#mapredwork" >}})
-		- [Semantic analysis and logical optimizations]({{< ref "#semantic-analysis-and-logical-optimizations" >}})
-		- [Physical Optimizations and Task generation]({{< ref "#physical-optimizations-and-task-generation" >}})
-		- [Local Job Runner]({{< ref "#local-job-runner" >}})
-		- [Number of tasks]({{< ref "#number-of-tasks" >}})
-		- [Explain statements]({{< ref "#explain-statements" >}})
-		- [Hive variables]({{< ref "#hive-variables" >}})
-	+ [Build infrastructure]({{< ref "#build-infrastructure" >}})
-	+ [Testing]({{< ref "#testing" >}})
-		- [Mini Tez Cluster]({{< ref "#mini-tez-cluster" >}})
-* [Installation and Configuration]({{< ref "#installation-and-configuration" >}})
-	+ [Hive-Tez Compatibility]({{< ref "#hive-tez-compatibility" >}})
+{{< toc >}}
 
 # Overview
 

--- a/content/docs/latest/hive-schema-tool_34835119.md
+++ b/content/docs/latest/hive-schema-tool_34835119.md
@@ -5,10 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : Hive Schema Tool
 
-* [Metastore Schema Verification]({{< ref "#metastore-schema-verification" >}})
-* [The Hive Schema Tool]({{< ref "#the-hive-schema-tool" >}})
-	+ [The schematool Command]({{< ref "#the-schematool-command" >}})
-	+ [Usage Examples]({{< ref "#usage-examples" >}})
+{{< toc >}}
 
 ## Metastore Schema Verification
 

--- a/content/docs/latest/hive-transactions_40509723.md
+++ b/content/docs/latest/hive-transactions_40509723.md
@@ -3,34 +3,11 @@ title: "Apache Hive : Hive Transactions"
 date: 2024-12-12
 ---
 
-# Apache Hive : Hive Transactions
+# Apache Hive : ACID Transactions
 
-# ACID and Transactions in Hive
+{{< toc >}}
 
-* [ACID and Transactions in Hive]({{< ref "#acid-and-transactions-in-hive" >}})
-	+ [What is ACID and why should you use it?]({{< ref "#what-is-acid-and-why-should-you-use-it" >}})
-	+ [Limitations]({{< ref "#limitations" >}})
-	+ [Streaming APIs]({{< ref "#streaming-apis" >}})
-	+ [Grammar Changes]({{< ref "#grammar-changes" >}})
-	+ [Basic Design]({{< ref "#basic-design" >}})
-		- [Base and Delta Directories]({{< ref "#base-and-delta-directories" >}})
-		- [Compactor]({{< ref "#compactor" >}})
-			* [Delta File Compaction]({{< ref "#delta-file-compaction" >}})
-			* [Initiator]({{< ref "#initiator" >}})
-			* [Worker]({{< ref "#worker" >}})
-			* [Cleaner]({{< ref "#cleaner" >}})
-			* [AcidHouseKeeperService]({{< ref "#acidhousekeeperservice" >}})
-			* [SHOW COMPACTIONS]({{< ref "#show-compactions" >}})
-		- [Transaction/Lock Manager]({{< ref "#transactionlock-manager" >}})
-	+ [Configuration]({{< ref "#configuration" >}})
-		- [New Configuration Parameters for Transactions]({{< ref "#new-configuration-parameters-for-transactions" >}})
-		- [Configuration Values to Set for INSERT, UPDATE, DELETE]({{< ref "#configuration-values-to-set-for-insert,-update,-delete" >}})
-		- [Configuration Values to Set for Compaction]({{< ref "#configuration-values-to-set-for-compaction" >}})
-		- [Compaction pooling]({{< ref "#compaction-pooling" >}})
-	+ [Table Properties]({{< ref "#table-properties" >}})
-* [Talks and Presentations]({{< ref "#talks-and-presentations" >}})
-
-Hive 3 Warning
+## Upgrade to Hive 3+
 
 Any transactional tables created by a Hive version prior to Hive 3 require Major Compaction to be run on every partition before upgrading to 3.0.  More precisely, any partition which has had any update/delete/merge statements executed on it since the last Major Compaction, has to undergo another Major Compaction.  No more update/delete/merge may happen on this partition until after Hive is upgraded to Hive 3.
 

--- a/content/docs/latest/hive-udfs_282102277.md
+++ b/content/docs/latest/hive-udfs_282102277.md
@@ -5,22 +5,11 @@ date: 2024-12-12
 
 # Apache Hive : Hive UDFs
 
-* [Built-in Aggregate Functions (UDAF)]({{< ref "#built-in-aggregate-functions-udaf" >}})
-* [Built-in Table-Generating Functions (UDTF)]({{< ref "#built-in-table-generating-functions-udtf" >}})
-* [String Functions]({{< ref "#string-functions" >}})
-* [Date Functions]({{< ref "#date-functions" >}})
-* [Mathematical Functions]({{< ref "#mathematical-functions" >}})
-* [Collection Functions]({{< ref "#collection-functions" >}})
-* [Type Conversion Functions]({{< ref "#type-conversion-functions" >}})
-* [Conditional Functions]({{< ref "#conditional-functions" >}})
-* [Data Masking Functions]({{< ref "#data-masking-functions" >}})
-* [Miscellaneous Functions]({{< ref "#miscellaneous-functions" >}})
-* [Geospatial]({{< ref "#geospatial" >}})
-* [Creating Custom UDF's]({{< ref "#creating-custom-udfs" >}})
-
 Hive User-Defined Functions (UDFs) are custom functions developed in Java and seamlessly integrated with Apache Hive. UDFs are routines designed to accept parameters, execute a specific action, and return the resulting value. The return value can either be a single scalar row or a complete result set, depending on the UDF's code and the implemented interface. UDFs represent a powerful capability that enhances classical SQL functionality by allowing the integration of custom code, providing Hive users with a versatile toolset. Apache Hive comes equipped with a variety of built-in UDFs that users can leverage. Similar to other SQL-based solutions, Hive also offers functionality to expand its already rich set of UDFs by incorporating custom ones as needed.
 
-Important
+{{< toc >}}
+
+## Overview
 
 Every UDF's evaluate method is one row at a time! This means if your UDFs has complex code, it could introduce performance issue in execution time.
 
@@ -39,6 +28,8 @@ As we see how a built-in UDF works let's see what kind of built-in UDFs the Apac
 Tipp
 
 All Hive keywords are **case-insensitive**, including the names of Hive operators and functions. I.e: length and LENGTH are also accepted by the Hive.
+
+## Available function
 
 ### Built-in Aggregate Functions (UDAF)
 

--- a/content/docs/latest/hiveclient_27362101.md
+++ b/content/docs/latest/hiveclient_27362101.md
@@ -5,23 +5,11 @@ date: 2024-12-12
 
 # Apache Hive : HiveClient
 
-* [Command Line]({{< ref "#command-line" >}})
-* [JDBC]({{< ref "#jdbc" >}})
-	+ [JDBC Client Sample Code]({{< ref "#jdbc-client-sample-code" >}})
-		- [Running the JDBC Sample Code]({{< ref "#running-the-jdbc-sample-code" >}})
-	+ [JDBC Client Setup for a Secure Cluster]({{< ref "#jdbc-client-setup-for-a-secure-cluster" >}})
-* [Python]({{< ref "#python" >}})
-* [PHP]({{< ref "#php" >}})
-* [ODBC]({{< ref "#odbc" >}})
-* [Thrift]({{< ref "#thrift" >}})
-	+ [Thrift Java Client]({{< ref "#thrift-java-client" >}})
-	+ [Thrift C++ Client]({{< ref "#thrift-c-client" >}})
-	+ [Thrift Node Clients]({{< ref "#thrift-node-clients" >}})
-	+ [Thrift Ruby Client]({{< ref "#thrift-ruby-client" >}})
-
 This page describes the different clients supported by Hive. The command line client currently only supports an embedded server. The JDBC and Thrift-Java clients support both embedded and standalone servers. Clients in other languages only support standalone servers.
 
 For details about the standalone server see [Hive Server]({{< ref "hiveserver_27362111" >}}) or [HiveServer2]({{< ref "setting-up-hiveserver2_30758712" >}}).
+
+{{< toc >}}
 
 # Command Line
 

--- a/content/docs/latest/hivederbyservermode_27362068.md
+++ b/content/docs/latest/hivederbyservermode_27362068.md
@@ -3,22 +3,13 @@ title: "Apache Hive : HiveDerbyServerMode"
 date: 2024-12-12
 ---
 
-# Apache Hive : HiveDerbyServerMode
-
-# Hive Using Derby in Server Mode
-
-* [Hive Using Derby in Server Mode]({{< ref "#hive-using-derby-in-server-mode" >}})
-	+ [Download Derby]({{< ref "#download-derby" >}})
-	+ [Set Environment]({{< ref "#set-environment" >}})
-	+ [Starting Derby]({{< ref "#starting-derby" >}})
-	+ [Configure Hive to Use Network Derby]({{< ref "#configure-hive-to-use-network-derby" >}})
-	+ [Copy Derby Jar Files]({{< ref "#copy-derby-jar-files" >}})
-	+ [Start Up Hive]({{< ref "#start-up-hive" >}})
-	+ [The Result]({{< ref "#the-result" >}})
+# Apache Hive : Using Derby in Server Mode
 
 Hive in embedded mode has a limitation of one active user at a time. You may want to run [Derby](http://db.apache.org/derby/) as a Network Server, this way multiple users can access it simultaneously from different systems.
 
 See [Metadata Store]({{< ref "#metadata-store" >}}) and [Embedded Metastore]({{< ref "#embedded-metastore" >}}) for more information.
+
+{{< toc >}}
 
 ### Download Derby
 

--- a/content/docs/latest/hivejdbcinterface_27362100.md
+++ b/content/docs/latest/hivejdbcinterface_27362100.md
@@ -3,17 +3,13 @@ title: "Apache Hive : HiveJDBCInterface"
 date: 2024-12-12
 ---
 
-# Apache Hive : HiveJDBCInterface
-
-# Hive JDBC Driver
-
-* [Hive JDBC Driver]({{< ref "#hive-jdbc-driver" >}})
-	+ [Integration with Pentaho]({{< ref "#integration-with-pentaho" >}})
-	+ [Integration with SQuirrel SQL Client]({{< ref "#integration-with-squirrel-sql-client" >}})
+# Apache Hive : JDBC Driver
 
 The current JDBC interface for Hive only supports running queries and fetching results. Only a small subset of the metadata calls are supported.
 
 To see how the JDBC interface can be used, see [sample code]({{< ref "hiveclient_27362101" >}}).
+
+{{< toc >}}
 
 ### Integration with Pentaho
 

--- a/content/docs/latest/hiveodbc_27362099.md
+++ b/content/docs/latest/hiveodbc_27362099.md
@@ -3,32 +3,18 @@ title: "Apache Hive : HiveODBC"
 date: 2024-12-12
 ---
 
-# Apache Hive : HiveODBC
-
-# Hive ODBC Driver
-
-* [Hive ODBC Driver]({{< ref "#hive-odbc-driver" >}})
-	+ [Introduction]({{< ref "#introduction" >}})
-		- [Suggested Reading]({{< ref "#suggested-reading" >}})
-		- [Software Requirements]({{< ref "#software-requirements" >}})
-		- [Driver Architecture]({{< ref "#driver-architecture" >}})
-	+ [Building and Setting Up ODBC Components]({{< ref "#building-and-setting-up-odbc-components" >}})
-		- [Hive Client Build/Setup]({{< ref "#hive-client-buildsetup" >}})
-		- [unixODBC API Wrapper Build/Setup]({{< ref "#unixodbc-api-wrapper-buildsetup" >}})
-		- [Connecting the Driver to a Driver Manager]({{< ref "#connecting-the-driver-to-a-driver-manager" >}})
-		- [Testing with ISQL]({{< ref "#testing-with-isql" >}})
-		- [Build libodbchive.so for 3rd Party Driver Manager]({{< ref "#build-libodbchiveso-for-3rd-party-driver-manager" >}})
-		- [Troubleshooting]({{< ref "#troubleshooting" >}})
-	+ [Current Status]({{< ref "#current-status" >}})
+# Apache Hive : ODBC Driver
 
 These instructions are for the Hive ODBC driver available in Hive for [HiveServer1]({{< ref "hiveserver_27362111" >}}).  
 There is no ODBC driver available for [HiveServer2]({{< ref "setting-up-hiveserver2_30758712" >}}) as part of Apache Hive. There are third party ODBC drivers available from different vendors, and most of them seem to be free.
 
-**HiveServer was removed from Hive releases starting with Hive 1.0.0. See [HIVE-6977](https://issues.apache.org/jira/browse/HIVE-6977). Please switch over to HiveServer2.**
+{{< toc >}}
 
 ## Introduction
 
 The Hive ODBC Driver is a software library that implements the Open Database Connectivity (ODBC) API standard for the Hive database management system, enabling ODBC compliant applications to interact seamlessly (ideally) with Hive through a standard interface. This driver will NOT be built as a part of the typical Hive build process and will need to be compiled and built separately according to the instructions below.
+
+**HiveServer was removed from Hive releases starting with Hive 1.0.0. See [HIVE-6977](https://issues.apache.org/jira/browse/HIVE-6977). Please switch over to HiveServer2.**
 
 ### Suggested Reading
 

--- a/content/docs/latest/hiveplugins_27362098.md
+++ b/content/docs/latest/hiveplugins_27362098.md
@@ -3,10 +3,9 @@ title: "Apache Hive : HivePlugins"
 date: 2024-12-12
 ---
 
-# Apache Hive : HivePlugins
+# Apache Hive : Plugins
 
-* [Creating Custom UDFs]({{< ref "#creating-custom-udfs" >}})
-* [Deploying Jars for User Defined Functions and User Defined SerDes]({{< ref "#deploying-jars-for-user-defined-functions-and-user-defined-serdes" >}})
+{{< toc >}}
 
 ## Creating Custom UDFs
 

--- a/content/docs/latest/hivereplicationdevelopment_55155632.md
+++ b/content/docs/latest/hivereplicationdevelopment_55155632.md
@@ -5,29 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : HiveReplicationDevelopment
 
-* [Introduction]({{< ref "#introduction" >}})
-	+ [Purposes of Replication]({{< ref "#purposes-of-replication" >}})
-		- [Disaster Recovery]({{< ref "#disaster-recovery" >}})
-		- [Load Balancing]({{< ref "#load-balancing" >}})
-	+ [Replication Taxonomy]({{< ref "#replication-taxonomy" >}})
-		- [Transaction Source]({{< ref "#transaction-source" >}})
-			* [Primary-Copy]({{< ref "#primary-copy" >}})
-			* [Update-Anywhere]({{< ref "#update-anywhere" >}})
-		- [Synchronization Strategy]({{< ref "#synchronization-strategy" >}})
-			* [Eager]({{< ref "#eager" >}})
-			* [Lazy]({{< ref "#lazy" >}})
-* [Design]({{< ref "#design" >}})
-	+ [Taxonomy Design Choices]({{< ref "#taxonomy-design-choices" >}})
-		- [Primary-Copy vs Update-Anywhere]({{< ref "#primary-copy-vs-update-anywhere" >}})
-		- [Eager vs Lazy]({{< ref "#eager-vs-lazy" >}})
-	+ [Other Design Choices]({{< ref "#other-design-choices" >}})
-	+ [Basic Approach]({{< ref "#basic-approach" >}})
-* [Implementation]({{< ref "#implementation" >}})
-	+ [Events]({{< ref "#events" >}})
-	+ [Event IDs, State IDs, and Sequencing of Exports/Imports]({{< ref "#event-ids-state-ids-and-sequencing-of-exportsimports" >}})
-	+ [Handling of Events]({{< ref "#handling-of-events" >}})
-* [Future Features]({{< ref "#future-features" >}})
-* [References]({{< ref "#references" >}})
+{{< toc >}}
 
 # Introduction
 

--- a/content/docs/latest/hivereplicationv2development_66850051.md
+++ b/content/docs/latest/hivereplicationv2development_66850051.md
@@ -5,37 +5,15 @@ date: 2024-12-12
 
 # Apache Hive : HiveReplicationv2Development
 
-* [Issues with the Current Replication System]({{< ref "#issues-with-the-current-replication-system" >}})
-	+ [Slowness]({{< ref "#slowness" >}})
-	+ [Requiring Staging Directories with Full Copies (4xcopy Problem)]({{< ref "#requiring-staging-directories-with-full-copies-4xcopy-problem" >}})
-	+ [Unsuitable for Load-Balancing Use Cases]({{< ref "#unsuitable-for-load-balancing-use-cases" >}})
-	+ [Incompatibility with ACID]({{< ref "#incompatibility-with-acid" >}})
-	+ [Dependency on External Tools To Do a Lot]({{< ref "#dependency-on-external-tools-to-do-a-lot" >}})
-	+ [Support for a Hub-Spoke Model]({{< ref "#support-for-a-hub-spoke-model" >}})
-* [Rubberbanding]({{< ref "#rubberbanding" >}})
-* [Change Management]({{< ref "#change-management" >}})
-	+ [_files]({{< ref "#_files" >}})
-	+ [Solution for Rubber Banding]({{< ref "#solution-for-rubber-banding" >}})
-	+ [_metadata]({{< ref "#_metadata" >}})
-* [A Need for Bootstrap]({{< ref "#a-need-for-bootstrap" >}})
-* [New Commands]({{< ref "#new-commands" >}})
-	+ [REPL DUMP]({{< ref "#repl-dump" >}})
-		- [Syntax:]({{< ref "#syntax" >}})
-		- [Return values:]({{< ref "#return-values" >}})
-		- [Note:]({{< ref "#note" >}})
-	+ [REPL LOAD]({{< ref "#repl-load" >}})
-		- [Return values:]({{< ref "#return-values" >}})
-	+ [REPL STATUS]({{< ref "#repl-status" >}})
-		- [Return values:]({{< ref "#return-values" >}})
-* [Bootstrap, Revisited]({{< ref "#bootstrap-revisited" >}})
-* [Metastore notification API security]({{< ref "#metastore-notification-api-security" >}})
-* [Setup/Configuration]({{< ref "#setupconfiguration" >}})
-
 This document describes the second version of Hive Replication. Please refer to the [first version of Hive Replication]({{< ref "hivereplicationdevelopment_55155632" >}}) for details on prior implementation.
 
 This work is under development and interfaces are subject to change. This has been designed for use in conjunction with external orchestration tools, which would be responsible for co-ordinating the right sequence of commands between source and target clusters, fault tolerance/failure handling, and also providing correct configuration options that are necessary to be able to do cross cluster replication.
 
-**As of Hive 3.0.0 release : only managed table replication where Hive user owns the table contents is supported. External tables, ACID tables, statistics and constraint replication are not supported.**
+{{< toc >}}
+
+# Version information
+
+As of Hive 3.0.0 release : only managed table replication where Hive user owns the table contents is supported. External tables, ACID tables, statistics and constraint replication are not supported.
 
 # Issues with the Current Replication System
 

--- a/content/docs/latest/hiveserver2-clients_30758725.md
+++ b/content/docs/latest/hiveserver2-clients_30758725.md
@@ -5,63 +5,11 @@ date: 2024-12-12
 
 # Apache Hive : HiveServer2 Clients
 
-* [Beeline – Command Line Shell]({{< ref "#beeline--command-line-shell" >}})
-	+ [Beeline Example]({{< ref "#beeline-example" >}})
-	+ [Beeline Commands]({{< ref "#beeline-commands" >}})
-	+ [Beeline Properties]({{< ref "#beeline-properties" >}})
-	+ [Beeline Hive Commands]({{< ref "#beeline-hive-commands" >}})
-	+ [Beeline Command Options]({{< ref "#beeline-command-options" >}})
-	+ [Output Formats]({{< ref "#output-formats" >}})
-		- [table]({{< ref "#table" >}})
-		- [vertical]({{< ref "#vertical" >}})
-		- [xmlattr]({{< ref "#xmlattr" >}})
-		- [xmlelements]({{< ref "#xmlelements" >}})
-		- [json]({{< ref "#json" >}})
-		- [jsonfile]({{< ref "#jsonfile" >}})
-		- [Separated-Value Output Formats]({{< ref "#separated-value-output-formats" >}})
-			* [csv2, tsv2, dsv]({{< ref "#csv2-tsv2-dsv" >}})
-				+ [Quoting in csv2, tsv2 and dsv Formats]({{< ref "#quoting-in-csv2,-tsv2-and-dsv-formats" >}})
-			* [csv, tsv]({{< ref "#csv,-tsv" >}})
-	+ [HiveServer2 Logging]({{< ref "#hiveserver2-logging" >}})
-	+ [Cancelling the Query]({{< ref "#cancelling-the-query" >}})
-	+ [Background Query in Terminal Script]({{< ref "#background-query-in-terminal-script" >}})
-* [JDBC]({{< ref "#jdbc" >}})
-	+ [Connection URLs]({{< ref "#connection-urls" >}})
-		- [Connection URL Format]({{< ref "#connection-url-format" >}})
-		- [Connection URL for Remote or Embedded Mode]({{< ref "#connection-url-for-remote-or-embedded-mode" >}})
-		- [Connection URL When HiveServer2 Is Running in HTTP Mode]({{< ref "#connection-url-when-hiveserver2-is-running-in-http-mode" >}})
-		- [Connection URL When SSL Is Enabled in HiveServer2]({{< ref "#connection-url-when-ssl-is-enabled-in-hiveserver2" >}})
-		- [Connection URL When ZooKeeper Service Discovery Is Enabled]({{< ref "#connection-url-when-zookeeper-service-discovery-is-enabled" >}})
-		- [Named Connection URLs]({{< ref "#named-connection-urls" >}})
-		- [Reconnecting]({{< ref "#reconnecting" >}})
-		- [Using hive-site.xml to automatically connect to HiveServer2]({{< ref "#using-hive-sitexml-to-automatically-connect-to-hiveserver2" >}})
-		- [Using beeline-site.xml to automatically connect to HiveServer2]({{< ref "#using-beeline-sitexml-to-automatically-connect-to-hiveserver2" >}})
-		- [Using JDBC]({{< ref "#using-jdbc" >}})
-			* [JDBC Client Sample Code]({{< ref "#jdbc-client-sample-code" >}})
-			* [Running the JDBC Sample Code]({{< ref "#running-the-jdbc-sample-code" >}})
-	+ [JDBC Data Types]({{< ref "#jdbc-data-types" >}})
-	+ [JDBC Client Setup for a Secure Cluster]({{< ref "#jdbc-client-setup-for-a-secure-cluster" >}})
-		- [Multi-User Scenarios and Programmatic Login to Kerberos KDC]({{< ref "#multi-user-scenarios-and-programmatic-login-to-kerberos-kdc" >}})
-			* [Using Kerberos with a Pre-Authenticated Subject]({{< ref "#using-kerberos-with-a-pre-authenticated-subject" >}})
-	+ [JDBC Fetch Size]({{< ref "#jdbc-fetch-size" >}})
-* [Python Client]({{< ref "#python-client" >}})
-* [Ruby Client]({{< ref "#ruby-client" >}})
-* [Integration with SQuirrel SQL Client]({{< ref "#integration-with-squirrel-sql-client" >}})
-* [Integration with SQL Developer]({{< ref "#integration-with-sql-developer" >}})
-* [Integration with DbVisSoftware's DbVisualizer]({{< ref "#integration-with-dbvissoftwares-dbvisualizer" >}})
-* [Advanced Features for Integration with Other Tools]({{< ref "#advanced-features-for-integration-with-other-tools" >}})
-	+ [Supporting Cookie Replay in HTTP Mode]({{< ref "#supporting-cookie-replay-in-http-mode" >}})
-	+ [Using 2-way SSL in HTTP Mode]({{< ref "#using-2-way-ssl-in-http-mode" >}})
-	+ [Passing HTTP Header Key/Value Pairs via JDBC Driver]({{< ref "#passing-http-header-keyvalue-pairs-via-jdbc-driver" >}})
-	+ [Passing Custom HTTP Cookie Key/Value Pairs via JDBC Driver]({{< ref "#passing-custom-http-cookie-keyvalue-pairs-via-jdbc-driver" >}})
+This page describes the different clients supported by [HiveServer2]({{< ref "setting-up-hiveserver2_30758712" >}}).
 
-This page describes the different clients supported by [HiveServer2]({{< ref "setting-up-hiveserver2_30758712" >}}).  Other documentation for HiveServer2 includes:
+{{< toc >}}
 
-* [HiveServer2 Overview]({{< ref "hiveserver2-overview_65147648" >}})
-* [Setting Up HiveServer2]({{< ref "setting-up-hiveserver2_30758712" >}})
-* [Hive Configuration Properties:  HiveServer2]({{< ref "#hive-configuration-properties:- hiveserver2" >}})
-
-Version
+# Version information
 
 Introduced in Hive version 0.11. See [HIVE-2935](https://issues.apache.org/jira/browse/HIVE-2935).
 

--- a/content/docs/latest/hiveserver2-overview_65147648.md
+++ b/content/docs/latest/hiveserver2-overview_65147648.md
@@ -5,19 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : HiveServer2 Overview
 
-* [Introduction]({{< ref "#introduction" >}})
-* [HS2 Architecture]({{< ref "#hs2-architecture" >}})
-	+ [Server]({{< ref "#server" >}})
-	+ [Transport]({{< ref "#transport" >}})
-	+ [Protocol]({{< ref "#protocol" >}})
-	+ [Processor]({{< ref "#processor" >}})
-* [Dependencies of HS2]({{< ref "#dependencies-of-hs2" >}})
-* [JDBC Client]({{< ref "#jdbc-client" >}})
-* [Source Code Description]({{< ref "#source-code-description" >}})
-	+ [Server Side]({{< ref "#server-side" >}})
-	+ [Client Side]({{< ref "#client-side" >}})
-	+ [Interaction between Client and Server]({{< ref "#interaction-between-client-and-server" >}})
-* [Resources]({{< ref "#resources" >}})
+{{< toc >}}
 
 # Introduction
 

--- a/content/docs/latest/home_27362069.md
+++ b/content/docs/latest/home_27362069.md
@@ -5,14 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : Home
 
-* [Apache Hive]({{< ref "#apache-hive" >}})
-* [Hive Documentation]({{< ref "#hive-documentation" >}})
-	+ [General Information about Hive]({{< ref "#general-information-about-hive" >}})
-	+ [User Documentation]({{< ref "#user-documentation" >}})
-	+ [Administrator Documentation]({{< ref "#administrator-documentation" >}})
-	+ [HCatalog and WebHCat Documentation]({{< ref "#hcatalog-and-webhcat-documentation" >}})
-	+ [Resources for Contributors]({{< ref "#resources-for-contributors" >}})
-* [Hive Versions and Branches]({{< ref "#hive-versions-and-branches" >}})
+{{< toc >}}
 
 # Apache Hive
 

--- a/content/docs/latest/howtocommit_27362108.md
+++ b/content/docs/latest/howtocommit_27362108.md
@@ -3,21 +3,11 @@ title: "Apache Hive : HowToCommit"
 date: 2024-12-12
 ---
 
-# Apache Hive : HowToCommit
-
-# Guide for Hive Committers
-
-* [Guide for Hive Committers]({{< ref "#guide-for-hive-committers" >}})
-	+ [New committers]({{< ref "#new-committers" >}})
-	+ [Review]({{< ref "#review" >}})
-	+ [Reject]({{< ref "#reject" >}})
-	+ [PreCommit runs, and committing patches]({{< ref "#precommit-runs-and-committing-patches" >}})
-	+ [Commit]({{< ref "#commit" >}})
-		- [Committing Documentation]({{< ref "#committing-documentation" >}})
-	+ [Backporting commits to previous branches]({{< ref "#backporting-commits-to-previous-branches" >}})
-	+ [Dialog]({{< ref "#dialog" >}})
+# Apache Hive : Guide for Committers
 
 This page contains guidelines for committers of the Apache Hive project. (If you're currently a contributor, and are interested in how we add new committers, read [BecomingACommitter]({{< ref "/community/becomingcommitter" >}}))
+
+{{< toc >}}
 
 ## New committers
 

--- a/content/docs/latest/howtocontribute_27362107.md
+++ b/content/docs/latest/howtocontribute_27362107.md
@@ -3,9 +3,7 @@ title: "Apache Hive : HowToContribute"
 date: 2024-12-12
 ---
 
-# Apache Hive : HowToContribute
-
-# How to Contribute to Apache Hive
+# Apache Hive : How to Contribute
 
 This page describes the mechanics of *how* to contribute software to Apache Hive. For ideas about *what* you might contribute, please see open tickets in [Jira](https://issues.apache.org/jira/browse/HIVE).
 

--- a/content/docs/latest/howtorelease_27362106.md
+++ b/content/docs/latest/howtorelease_27362106.md
@@ -5,29 +5,11 @@ date: 2024-12-12
 
 # Apache Hive : HowToRelease
 
-*This page is prepared for Hive committers. You need committer rights to create a new Hive release.*
+{{< toc >}}
 
-##
-* [Storage API Release]({{< ref "#storage-api-release" >}})
-	+ [Storage API Prepare Master Branch]({{< ref "#storage-api-prepare-master-branch" >}})
-	+ [Storage API Branching]({{< ref "#storage-api-branching" >}})
-	+ [Making Storage API Release Artifacts]({{< ref "#making-storage-api-release-artifacts" >}})
-	+ [Publishing the Storage API Artifacts]({{< ref "#publishing-the-storage-api-artifacts" >}})
-	+ [Preparing Branch for further development]({{< ref "#preparing-branch-for-further-development" >}})
-	+ [Cleaning Up Storage API Artifacts]({{< ref "#cleaning-up-storage-api-artifacts" >}})
-* [Hive Release]({{< ref "#hive-release" >}})
-	+ [Preparation]({{< ref "#preparation" >}})
-	+ [Branching]({{< ref "#branching" >}})
-	+ [Updating Release Branch]({{< ref "#updating-release-branch" >}})
-	+ [Building]({{< ref "#building" >}})
-	+ [Voting]({{< ref "#voting" >}})
-	+ [Verifying the Release Candidate]({{< ref "#verifying-the-release-candidate" >}})
-	+ [Publishing]({{< ref "#publishing" >}})
-	+ [Archive old releases]({{< ref "#archive-old-releases" >}})
-	+ [Preparing Branch for Future Maintenance Release]({{< ref "#preparing-branch-for-future-maintenance-release" >}})
-* [See Also]({{< ref "#see-also" >}})
+## Introduction
 
-Hadoop Version Warning
+This page is prepared for Hive committers. You need committer rights to create a new Hive release. 
 
 This page assumes you are releasing from the master branch, and thus omits the use of Maven profiles to determine which version of Hadoop you are building against. If you are releasing from branch-1, you will need to add `-Phadoop-2` to most of your Maven commands.
 
@@ -144,12 +126,7 @@ sftp> quit
 % git push origin rel/storage-release-X.Y.Z
 ```
 4. Add the artifacts to Hive's dist area. There might be a problem with the size of the artifact. 
-
-[INFRA-23055](https://issues.apache.org/jira/browse/INFRA-23055?src=confmacro)
- -
- [Authenticate](https://cwiki.apache.org/confluence/plugins/servlet/applinks/oauth/login-dance/authorize?applicationLinkID=5aa69414-a9e9-3523-82ec-879b028fb15b) to see issue details
-
- solved the issue.
+[INFRA-23055](https://issues.apache.org/jira/browse/INFRA-23055) solved the issue.
 
 ```
 % svn checkout https://dist.apache.org/repos/dist/release/hive hive-dist
@@ -395,11 +372,7 @@ git push origin :release-X.Y.Z-rcR
 ```
 
 If errors happen while "git tag -s", try to configure the git signing key by "git config user.signingkey your_gpg_key_id" then rerun the command.
-2. Move the release artifacts to the release area of the project (<https://dist.apache.org/repos/dist/release/hive/>). Using svn mv command is important otherwise you may hit size limitations applying to artifacts(
-
-[INFRA-23055](https://issues.apache.org/jira/browse/INFRA-23055?src=confmacro)
- -
- [Authenticate](https://cwiki.apache.org/confluence/plugins/servlet/applinks/oauth/login-dance/authorize?applicationLinkID=5aa69414-a9e9-3523-82ec-879b028fb15b) to see issue details
+2. Move the release artifacts to the release area of the project (<https://dist.apache.org/repos/dist/release/hive/>). Using svn mv command is important otherwise you may hit size limitations applying to artifacts([INFRA-23055](https://issues.apache.org/jira/browse/INFRA-23055))
 
 ```
 svn mv https://dist.apache.org/repos/dist/dev/hive/hive-X.Y.Z https://dist.apache.org/repos/dist/release/hive/hive-X.Y.Z -m "Move hive-X.Y.Z release from dev to release"

--- a/content/docs/latest/indexdev-bitmap_27362028.md
+++ b/content/docs/latest/indexdev-bitmap_27362028.md
@@ -3,16 +3,9 @@ title: "Apache Hive : IndexDev Bitmap"
 date: 2024-12-12
 ---
 
-# Apache Hive : IndexDev Bitmap
+# Apache Hive : Bitmap Indexing
 
-= Bitmap Indexing =
-
-* [Introduction]({{< ref "#introduction" >}})
-* [Approach]({{< ref "#approach" >}})
-* [Proposal]({{< ref "#proposal" >}})
-	+ [First implementation]({{< ref "#first-implementation" >}})
-	+ [Second iteration]({{< ref "#second-iteration" >}})
-* [Example]({{< ref "#example" >}})
+{{< toc >}}
 
 ## Introduction
 

--- a/content/docs/latest/indexdev_27362104.md
+++ b/content/docs/latest/indexdev_27362104.md
@@ -3,23 +3,9 @@ title: "Apache Hive : IndexDev"
 date: 2024-12-12
 ---
 
-# Apache Hive : IndexDev
+# Apache Hive : Indexes
 
-# Indexes
-
-* [Indexes]({{< ref "#indexes" >}})
-	+ [Indexing Is Removed since 3.0]({{< ref "#indexing-is-removed-since-30" >}})
-	+ [Introduction]({{< ref "#introduction" >}})
-	+ [Scope]({{< ref "#scope" >}})
-	+ [CREATE INDEX]({{< ref "#create-index" >}})
-	+ [Metastore Model]({{< ref "#metastore-model" >}})
-	+ [Metastore Upgrades]({{< ref "#metastore-upgrades" >}})
-	+ [REBUILD]({{< ref "#rebuild" >}})
-	+ [DROP INDEX]({{< ref "#drop-index" >}})
-	+ [Plugin Interface]({{< ref "#plugin-interface" >}})
-	+ [Reference Implementation]({{< ref "#reference-implementation" >}})
-	+ [TBD]({{< ref "#tbd" >}})
-	+ [Current Status (JIRA)]({{< ref "#current-status-jira" >}})
+{{< toc >}}
 
 ## Indexing Is Removed since 3.0
 

--- a/content/docs/latest/jdbc-storage-handler_95651916.md
+++ b/content/docs/latest/jdbc-storage-handler_95651916.md
@@ -5,21 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : JDBC Storage Handler
 
-# 
-* 
-* [Syntax]({{< ref "#syntax" >}})
-	+ [Table Properties]({{< ref "#table-properties" >}})
-	+ [Supported Data Type]({{< ref "#supported-data-type" >}})
-	+ [Column/Type Mapping]({{< ref "#columntype-mapping" >}})
-* [Auto Shipping]({{< ref "#auto-shipping" >}})
-* [Securing Password]({{< ref "#securing-password" >}})
-* [Partitioning]({{< ref "#partitioning" >}})
-* [Computation Pushdown]({{< ref "#computation-pushdown" >}})
-* [Using a Non-default Schema]({{< ref "#using-a-non-default-schema" >}})
-	+ [MariaDB]({{< ref "#mariadb" >}})
-	+ [MS SQL]({{< ref "#ms-sql" >}})
-	+ [Oracle]({{< ref "#oracle" >}})
-	+ [PostgreSQL]({{< ref "#postgresql" >}})
+{{< toc >}}
 
 # Syntax
 

--- a/content/docs/latest/kudu-integration_133631955.md
+++ b/content/docs/latest/kudu-integration_133631955.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : Kudu Integration
 
-# Hive Kudu Integration
-
-* [Hive Kudu Integration]({{< ref "#hive-kudu-integration" >}})
-	+ [Overview]({{< ref "#overview" >}})
-	+ [Implementation]({{< ref "#implementation" >}})
-	+ [Hive Configuration]({{< ref "#hive-configuration" >}})
-	+ [Table Creation]({{< ref "#table-creation" >}})
-	+ [Impala Tables]({{< ref "#impala-tables" >}})
-	+ [Data Ingest]({{< ref "#data-ingest" >}})
-		- [Examples]({{< ref "#examples" >}})
+{{< toc >}}
 
 ## Overview
 

--- a/content/docs/latest/languagemanual-archiving_27362031.md
+++ b/content/docs/latest/languagemanual-archiving_27362031.md
@@ -5,18 +5,9 @@ date: 2024-12-12
 
 # Apache Hive : LanguageManual Archiving
 
-# Archiving for File Count Reduction
+Archiving for File Count Reduction.
 
-Note: Archiving should be considered an advanced command due to the caveats involved.
-
-* [Archiving for File Count Reduction]({{< ref "#archiving-for-file-count-reduction" >}})
-	+ [Overview]({{< ref "#overview" >}})
-	+ [Settings]({{< ref "#settings" >}})
-	+ [Usage]({{< ref "#usage" >}})
-		- [Archive]({{< ref "#archive" >}})
-		- [Unarchive]({{< ref "#unarchive" >}})
-	+ [Cautions and Limitations]({{< ref "#cautions-and-limitations" >}})
-	+ [Under the Hood]({{< ref "#under-the-hood" >}})
+{{< toc >}}
 
 ## Overview
 
@@ -24,7 +15,8 @@ Due to the design of HDFS, the number of files in the filesystem directly affect
 
 The use of [Hadoop Archives](http://hadoop.apache.org/docs/stable1/hadoop_archives.html) is one approach to reducing the number of files in partitions. Hive has built-in support to convert files in existing partitions to a Hadoop Archive (HAR) so that a partition that may once have consisted of 100's of files can occupy just ~3 files (depending on settings). However, the trade-off is that queries may be slower due to the additional overhead in reading from the HAR.
 
-Note that archiving does NOT compress the files – HAR is analogous to the Unix tar command.
+Note: Archiving does NOT compress the files – HAR is analogous to the Unix tar command.
+Note: Archiving should be considered an advanced command due to the caveats involved.
 
 ## Settings
 

--- a/content/docs/latest/languagemanual-authorization_27362032.md
+++ b/content/docs/latest/languagemanual-authorization_27362032.md
@@ -5,20 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : LanguageManual Authorization
 
-Hive Authorization
-
-* [Introduction]({{< ref "#introduction" >}})
-* [Hive Authorization Options]({{< ref "#hive-authorization-options" >}})
-	+ [Use Cases]({{< ref "#use-cases" >}})
-	+ [Overview of Authorization Modes]({{< ref "#overview-of-authorization-modes" >}})
-		- [1 Storage Based Authorization in the Metastore Server]({{< ref "#1-storage-based-authorization-in-the-metastore-server" >}})
-			* [Fall Back Authorizer]({{< ref "#fall-back-authorizer" >}})
-		- [2 SQL Standards Based Authorization in HiveServer2]({{< ref "#2-sql-standards-based-authorization-in-hiveserver2" >}})
-		- [3 Authorization using Apache Ranger & Sentry]({{< ref "#3-authorization-using-apache-ranger--sentry" >}})
-		- [4 Old default Hive Authorization (Legacy Mode)]({{< ref "#4-old-default-hive-authorization-legacy-mode" >}})
-	+ [Addressing Authorization Needs of Multiple Use Cases]({{< ref "#addressing-authorization-needs-of-multiple-use-cases" >}})
-* [Explain Authorization]({{< ref "#explain-authorization" >}})
-* [More Information]({{< ref "#more-information" >}})
+{{< toc >}}
 
 ## Introduction
 

--- a/content/docs/latest/languagemanual-cli_27362033.md
+++ b/content/docs/latest/languagemanual-cli_27362033.md
@@ -3,23 +3,11 @@ title: "Apache Hive : LanguageManual Cli"
 date: 2024-12-12
 ---
 
-# Apache Hive : LanguageManual Cli
-
-# Hive CLI
-
-* [Hive CLI]({{< ref "#hive-cli" >}})
-* [Deprecation in favor of Beeline CLI]({{< ref "#deprecation-in-favor-of-beeline-cli" >}})
-	+ [Hive Command Line Options]({{< ref "#hive-command-line-options" >}})
-		- [Examples]({{< ref "#examples" >}})
-		- [The hiverc File]({{< ref "#the-hiverc-file" >}})
-		- [Logging]({{< ref "#logging" >}})
-		- [Tool to Clear Dangling Scratch Directories]({{< ref "#tool-to-clear-dangling-scratch-directories" >}})
-	+ [Hive Batch Mode Commands]({{< ref "#hive-batch-mode-commands" >}})
-	+ [Hive Interactive Shell Commands]({{< ref "#hive-interactive-shell-commands" >}})
-		- [Hive Resources]({{< ref "#hive-resources" >}})
-* [HCatalog CLI]({{< ref "#hcatalog-cli" >}})
+# Apache Hive : LanguageManual Hive CLI
 
 $HIVE_HOME/bin/hive is a shell utility which can be used to run Hive queries in either interactive or batch mode.
+
+{{< toc >}}
 
 # Deprecation in favor of Beeline CLI
 

--- a/content/docs/latest/languagemanual-ddl_27362034.md
+++ b/content/docs/latest/languagemanual-ddl_27362034.md
@@ -5,29 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : LanguageManual DDL
 
-Hive Data Definition Language
-
-* [Overview]({{< ref "#overview" >}})
-* [Keywords, Non-reserved Keywords and Reserved Keywords]({{< ref "#keywords-non-reserved-keywords-and-reserved-keywords" >}})
-* [Create/Drop/Alter/Use Database]({{< ref "#createdropalteruse-database" >}})
-* [Create/Drop/Alter Connector]({{< ref "#createdropalter-connector" >}})
-* [Create/Drop/Truncate Table]({{< ref "#createdroptruncate-table" >}})
-* [Alter Table/Partition/Column]({{< ref "#alter-tablepartitioncolumn" >}})
-* [Create/Drop/Alter View]({{< ref "#createdropalter-view" >}})
-* [Create/Drop/Alter Materialized View]({{< ref "#createdropalter-materialized-view" >}})
-* [Create/Drop/Alter Index]({{< ref "#create/drop/alter-index" >}})
-* [Create/Drop Macro]({{< ref "#createdrop-macro" >}})
-* [Create/Drop/Reload Function]({{< ref "#createdropreload-function" >}})
-* [Create/Drop/Grant/Revoke Roles and Privileges]({{< ref "#createdropgrantrevoke-roles-and-privileges" >}})
-* [Show]({{< ref "#show" >}})
-* [Describe]({{< ref "#describe" >}})
-* [Abort]({{< ref "#abort" >}})
-
-- [Scheduled queries]({{< ref "#scheduled-queries" >}})
-
-- [Datasketches integration]({{< ref "#datasketches-integration" >}})
-
-- [HCatalog and WebHCat DDL]({{< ref "#hcatalog-and-webhcat-ddl" >}})
+{{< toc >}}
 
 ## Overview
 
@@ -426,9 +404,7 @@ In the previous examples the data is stored in <hive.metastore.warehouse.dir>/pa
 #### External Tables
 
 The EXTERNAL keyword lets you create a table and provide a LOCATION so that Hive does not use a default location for this table. This comes in handy if you already have data generated. When dropping an EXTERNAL table, data in the table is *NOT* deleted from the file system. Starting Hive 4.0.0 (
-
-[![](https://issues.apache.org/jira/secure/viewavatar?size=xsmall&avatarId=21146&avatarType=issuetype)HIVE-19981](https://issues.apache.org/jira/browse/HIVE-19981?src=confmacro)
- -
+[HIVE-19981](https://issues.apache.org/jira/browse/HIVE-19981))
  Managed tables converted to external tables by the HiveStrictManagedMigration utility should be set to delete data when the table is dropped
 Closed
 
@@ -648,9 +624,7 @@ DROP TABLE [IF EXISTS] table_name [PURGE];     -- (Note: PURGE available in Hive
 DROP TABLE removes metadata and data for this table. The data is actually moved to the .Trash/Current directory if Trash is configured (and PURGE is not specified). The metadata is completely lost.
 
 When dropping an EXTERNAL table, data in the table will *NOT* be deleted from the file system. Starting Hive 4.0.0 (
-
-[![](https://issues.apache.org/jira/secure/viewavatar?size=xsmall&avatarId=21146&avatarType=issuetype)HIVE-19981](https://issues.apache.org/jira/browse/HIVE-19981?src=confmacro)
- -
+[HIVE-19981](https://issues.apache.org/jira/browse/HIVE-19981))
  Managed tables converted to external tables by the HiveStrictManagedMigration utility should be set to delete data when the table is dropped
 Closed
 

--- a/content/docs/latest/languagemanual-dml_27362036.md
+++ b/content/docs/latest/languagemanual-dml_27362036.md
@@ -7,53 +7,7 @@ date: 2024-12-12
 
 # Hive Data Manipulation Language
 
-* [Hive Data Manipulation Language]({{< ref "#hive-data-manipulation-language" >}})
-	+ [Loading files into tables]({{< ref "#loading-files-into-tables" >}})
-		- [Syntax]({{< ref "#syntax" >}})
-		- [Synopsis]({{< ref "#synopsis" >}})
-		- [Notes]({{< ref "#notes" >}})
-	+ [Inserting data into Hive Tables from queries]({{< ref "#inserting-data-into-hive-tables-from-queries" >}})
-		- [Syntax]({{< ref "#syntax" >}})
-		- [Synopsis]({{< ref "#synopsis" >}})
-		- [Notes]({{< ref "#notes" >}})
-		- [Dynamic Partition Inserts]({{< ref "#dynamic-partition-inserts" >}})
-			* [Example]({{< ref "#example" >}})
-			* [Additional Documentation]({{< ref "#additional-documentation" >}})
-	+ [Writing data into the filesystem from queries]({{< ref "#writing-data-into-the-filesystem-from-queries" >}})
-		- [Syntax]({{< ref "#syntax" >}})
-		- [Synopsis]({{< ref "#synopsis" >}})
-		- [Notes]({{< ref "#notes" >}})
-	+ [Inserting values into tables from SQL]({{< ref "#inserting-values-into-tables-from-sql" >}})
-		- [Syntax]({{< ref "#syntax" >}})
-		- [Synopsis]({{< ref "#synopsis" >}})
-		- [Examples]({{< ref "#examples" >}})
-	+ [Update]({{< ref "#update" >}})
-		- [Syntax]({{< ref "#syntax" >}})
-		- [Synopsis]({{< ref "#synopsis" >}})
-		- [Notes]({{< ref "#notes" >}})
-	+ [Delete]({{< ref "#delete" >}})
-		- [Syntax]({{< ref "#syntax" >}})
-		- [Synopsis]({{< ref "#synopsis" >}})
-		- [Notes]({{< ref "#notes" >}})
-	+ [Merge]({{< ref "#merge" >}})
-		- [Syntax]({{< ref "#syntax" >}})
-		- [Synopsis]({{< ref "#synopsis" >}})
-		- [Performance Note]({{< ref "#performance-note" >}})
-		- [Notes]({{< ref "#notes" >}})
-		- [Examples]({{< ref "#examples" >}})
-
-There are multiple ways to modify data in Hive:
-
-* [LOAD](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=82903069#LanguageManualDML-Loadingfilesintotables)
-* INSERT
-	+ [into Hive tables from queries](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=82903069#LanguageManualDML-InsertingdataintoHiveTablesfromqueries)
-	+ [into directories from queries](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=82903069#LanguageManualDML-Writingdataintothefilesystemfromqueries)
-	+ [into Hive tables from SQL](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=82903069#LanguageManualDML-InsertingintotablesfromSQL)
-* [UPDATE](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=82903069#LanguageManualDML-Update)
-* [DELETE](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=82903069#LanguageManualDML-Delete)
-* [MERGE](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=82903069#LanguageManualDML-Merge)
-
-[EXPORT and IMPORT]({{< ref "languagemanual-importexport_27837968" >}}) commands are also available (as of [Hive 0.8](https://issues.apache.org/jira/browse/HIVE-1918)).
+{{< toc >}}
 
 ### Loading files into tables
 

--- a/content/docs/latest/languagemanual-explain_27362037.md
+++ b/content/docs/latest/languagemanual-explain_27362037.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : LanguageManual Explain
 
-* [EXPLAIN Syntax]({{< ref "#explain-syntax" >}})
-	+ [Example]({{< ref "#example" >}})
-	+ [The CBO Clause]({{< ref "#the-cbo-clause" >}})
-	+ [The AST Clause]({{< ref "#the-ast-clause" >}})
-	+ [The DEPENDENCY Clause]({{< ref "#the-dependency-clause" >}})
-	+ [The AUTHORIZATION Clause]({{< ref "#the-authorization-clause" >}})
-	+ [The LOCKS Clause]({{< ref "#the-locks-clause" >}})
-	+ [The VECTORIZATION Clause]({{< ref "#the-vectorization-clause" >}})
-	+ [The ANALYZE Clause]({{< ref "#the-analyze-clause" >}})
-	+ [User-level Explain Output]({{< ref "#user-level-explain-output" >}})
+{{< toc >}}
 
 ## EXPLAIN Syntax
 

--- a/content/docs/latest/languagemanual-groupby_27362038.md
+++ b/content/docs/latest/languagemanual-groupby_27362038.md
@@ -5,13 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : LanguageManual GroupBy
 
-* [Group By Syntax]({{< ref "#group-by-syntax" >}})
-	+ [Simple Examples]({{< ref "#simple-examples" >}})
-	+ [Select statement and group by clause]({{< ref "#select-statement-and-group-by-clause" >}})
-* [Advanced Features]({{< ref "#advanced-features" >}})
-	+ [Multi-Group-By Inserts]({{< ref "#multi-group-by-inserts" >}})
-	+ [Map-side Aggregation for Group By]({{< ref "#map-side-aggregation-for-group-by" >}})
-	+ [Grouping Sets, Cubes, Rollups, and the GROUPING__ID Function]({{< ref "#grouping-sets-cubes-rollups-and-the-grouping__id-function" >}})
+{{< toc >}}
 
 ## Group By Syntax
 

--- a/content/docs/latest/languagemanual-importexport_27837968.md
+++ b/content/docs/latest/languagemanual-importexport_27837968.md
@@ -3,18 +3,11 @@ title: "Apache Hive : LanguageManual ImportExport"
 date: 2024-12-12
 ---
 
-# Apache Hive : LanguageManual ImportExport
+# Apache Hive : LanguageManual Import/Export
 
-# Import/Export
+{{< toc >}}
 
-* [Import/Export]({{< ref "#importexport" >}})
-	+ [Overview]({{< ref "#overview" >}})
-	+ [Export Syntax]({{< ref "#export-syntax" >}})
-	+ [Import Syntax]({{< ref "#import-syntax" >}})
-	+ [Replication usage]({{< ref "#replication-usage" >}})
-	+ [Examples]({{< ref "#examples" >}})
-
-Version
+### Version information
 
 The `EXPORT` and `IMPORT` commands were added in Hive 0.8.0 (see [HIVE-1918](https://issues.apache.org/jira/browse/HIVE-1918)).
 

--- a/content/docs/latest/languagemanual-indexing_31822176.md
+++ b/content/docs/latest/languagemanual-indexing_31822176.md
@@ -5,11 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : LanguageManual Indexing
 
-* [Indexing Is Removed since 3.0]({{< ref "#indexing-is-removed-since-30" >}})
-* [Overview of Hive Indexes]({{< ref "#overview-of-hive-indexes" >}})
-* [Indexing Resources]({{< ref "#indexing-resources" >}})
-	+ [Configuration Parameters for Hive Indexes]({{< ref "#configuration-parameters-for-hive-indexes" >}})
-* [Simple Examples]({{< ref "#simple-examples" >}})
+{{< toc >}}
 
 ## Indexing Is Removed since 3.0
 

--- a/content/docs/latest/languagemanual-joinoptimization_33293167.md
+++ b/content/docs/latest/languagemanual-joinoptimization_33293167.md
@@ -3,29 +3,9 @@ title: "Apache Hive : LanguageManual JoinOptimization"
 date: 2024-12-12
 ---
 
-# Apache Hive : LanguageManual JoinOptimization
+# Apache Hive : LanguageManual Join Optimization
 
-# Join Optimization
-
-* [Join Optimization]({{< ref "#join-optimization" >}})
-	+ [Improvements to the Hive Optimizer]({{< ref "#improvements-to-the-hive-optimizer" >}})
-	+ [Star Join Optimization]({{< ref "#star-join-optimization" >}})
-		- [Star Schema Example]({{< ref "#star-schema-example" >}})
-		- [Prior Support for MAPJOIN]({{< ref "#prior-support-for-mapjoin" >}})
-			* [Limitations of Prior Implementation]({{< ref "#limitations-of-prior-implementation" >}})
-		- [Enhancements for Star Joins]({{< ref "#enhancements-for-star-joins" >}})
-			* [Optimize Chains of Map Joins]({{< ref "#optimize-chains-of-map-joins" >}})
-				+ [Current and Future Optimizations]({{< ref "#current-and-future-optimizations" >}})
-			* [Optimize Auto Join Conversion]({{< ref "#optimize-auto-join-conversion" >}})
-				
-					- [Current Optimization]({{< ref "#current-optimization" >}})+ [Auto Conversion to SMB Map Join]({{< ref "#auto-conversion-to-smb-map-join" >}})
-					- [SMB Join across Tables with Different Keys]({{< ref "#smb-join-across-tables-with-different-keys" >}})
-			* [Generate Hash Tables on the Task Side]({{< ref "#generate-hash-tables-on-the-task-side" >}})
-				+ [Pros and Cons of Client-Side Hash Tables]({{< ref "#pros-and-cons-of-client-side-hash-tables" >}})
-				+ [Task-Side Generation of Hash Tables]({{< ref "#task-side-generation-of-hash-tables" >}})
-					- [Further Options for Optimization]({{< ref "#further-options-for-optimization" >}})
-
-For a general discussion of Hive joins including syntax, examples, and restrictions, see the [Joins](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Joins) wiki doc.
+{{< toc >}}
 
 ## Improvements to the Hive Optimizer
 

--- a/content/docs/latest/languagemanual-joins_27362039.md
+++ b/content/docs/latest/languagemanual-joins_27362039.md
@@ -5,15 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : LanguageManual Joins
 
-# Hive Joins
-
-* [Hive Joins]({{< ref "#hive-joins" >}})
-	+ [Join Syntax]({{< ref "#join-syntax" >}})
-	+ [Examples]({{< ref "#examples" >}})
-	+ [MapJoin Restrictions]({{< ref "#mapjoin-restrictions" >}})
-	+ [Join Optimization]({{< ref "#join-optimization" >}})
-		- [Predicate Pushdown in Outer Joins]({{< ref "#predicate-pushdown-in-outer-joins" >}})
-		- [Enhancements in Hive Version 0.11]({{< ref "#enhancements-in-hive-version-011" >}})
+{{< toc >}}
 
 ## Join Syntax
 

--- a/content/docs/latest/languagemanual-lateralview_27362040.md
+++ b/content/docs/latest/languagemanual-lateralview_27362040.md
@@ -5,11 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : LanguageManual LateralView
 
-* [Lateral View Syntax]({{< ref "#lateral-view-syntax" >}})
-* [Description]({{< ref "#description" >}})
-* [Example]({{< ref "#example" >}})
-* [Multiple Lateral Views]({{< ref "#multiple-lateral-views" >}})
-* [Outer Lateral Views]({{< ref "#outer-lateral-views" >}})
+{{< toc >}}
 
 ## Lateral View Syntax
 

--- a/content/docs/latest/languagemanual-lzo_33298193.md
+++ b/content/docs/latest/languagemanual-lzo_33298193.md
@@ -3,19 +3,9 @@ title: "Apache Hive : LanguageManual LZO"
 date: 2024-12-12
 ---
 
-# Apache Hive : LanguageManual LZO
+# Apache Hive : LanguageManual LZO Compression
 
-# LZO Compression
-
-* [LZO Compression]({{< ref "#lzo-compression" >}})
-	+ [General LZO Concepts]({{< ref "#general-lzo-concepts" >}})
-	+ [Prerequisites]({{< ref "#prerequisites" >}})
-		- [Lzo/Lzop Installations]({{< ref "#lzolzop-installations" >}})
-		- [core-site.xml]({{< ref "#core-site-xml" >}})
-		- [Table Definition]({{< ref "#table-definition" >}})
-	+ [Hive Queries]({{< ref "#hive-queries" >}})
-		- [Option 1: Directly Create LZO Files]({{< ref "#option-1-directly-create-lzo-files" >}})
-		- [Option 2: Write Custom Java to Create LZO Files]({{< ref "#option-2-write-custom-java-to-create-lzo-files" >}})
+{{< toc >}}
 
 ## General LZO Concepts
 

--- a/content/docs/latest/languagemanual-orc_31818911.md
+++ b/content/docs/latest/languagemanual-orc_31818911.md
@@ -5,20 +5,9 @@ date: 2024-12-12
 
 # Apache Hive : LanguageManual ORC
 
-# ORC Files
+{{< toc >}}
 
-* [ORC Files]({{< ref "#orc-files" >}})
-	+ [ORC File Format]({{< ref "#orc-file-format" >}})
-		- [File Structure]({{< ref "#file-structure" >}})
-		- [Stripe Structure]({{< ref "#stripe-structure" >}})
-	+ [HiveQL Syntax]({{< ref "#hiveql-syntax" >}})
-	+ [Serialization and Compression]({{< ref "#serialization-and-compression" >}})
-		- [Integer Column Serialization]({{< ref "#integer-column-serialization" >}})
-		- [String Column Serialization]({{< ref "#string-column-serialization" >}})
-		- [Compression]({{< ref "#compression" >}})
-	+ [ORC File Dump Utility]({{< ref "#orc-file-dump-utility" >}})
-	+ [ORC Configuration Parameters]({{< ref "#orc-configuration-parameters" >}})
-* [ORC Format Specification]({{< ref "#orc-format-specification" >}})
+# ORC Files
 
 ## ORC File Format
 

--- a/content/docs/latest/languagemanual-sampling_27362042.md
+++ b/content/docs/latest/languagemanual-sampling_27362042.md
@@ -5,9 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : LanguageManual Sampling
 
-* [Sampling Syntax]({{< ref "#sampling-syntax" >}})
-	+ [Sampling Bucketized Table]({{< ref "#sampling-bucketized-table" >}})
-	+ [Block Sampling]({{< ref "#block-sampling" >}})
+{{< toc >}}
 
 ## Sampling Syntax
 

--- a/content/docs/latest/languagemanual-select_27362043.md
+++ b/content/docs/latest/languagemanual-select_27362043.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : LanguageManual Select
 
-* [Select Syntax]({{< ref "#select-syntax" >}})
-	+ [WHERE Clause]({{< ref "#where-clause" >}})
-	+ [ALL and DISTINCT Clauses]({{< ref "#all-and-distinct-clauses" >}})
-	+ [Partition Based Queries]({{< ref "#partition-based-queries" >}})
-	+ [HAVING Clause]({{< ref "#having-clause" >}})
-	+ [LIMIT Clause]({{< ref "#limit-clause" >}})
-	+ [REGEX Column Specification]({{< ref "#regex-column-specification" >}})
-	+ [More Select Syntax]({{< ref "#more-select-syntax" >}})
-
-[GROUP BY]({{< ref "languagemanual-groupby_27362038" >}}); [SORT/ORDER/CLUSTER/DISTRIBUTE BY]({{< ref "languagemanual-sortby_27362045" >}}); [JOIN]({{< ref "languagemanual-joins_27362039" >}}) ([Hive Joins]({{< ref "languagemanual-joins_27362039" >}}), [Join Optimization]({{< ref "languagemanual-joinoptimization_33293167" >}}), [Outer Join Behavior]({{< ref "outerjoinbehavior_35749927" >}})); [UNION]({{< ref "languagemanual-union_27362049" >}}); [TABLESAMPLE]({{< ref "languagemanual-sampling_27362042" >}}); [Subqueries]({{< ref "languagemanual-subqueries_27362044" >}}); [Virtual Columns]({{< ref "languagemanual-virtualcolumns_27362048" >}}); [Operators and UDFs]({{< ref "languagemanual-udf_27362046" >}}); [LATERAL VIEW]({{< ref "languagemanual-lateralview_27362040" >}}); [Windowing, OVER, and Analytics]({{< ref "languagemanual-windowingandanalytics_31819589" >}}); [Common Table Expressions]({{< ref "common-table-expression_38572242" >}})
+{{< toc >}}
 
 ## Select Syntax
 

--- a/content/docs/latest/languagemanual-sortby_27362045.md
+++ b/content/docs/latest/languagemanual-sortby_27362045.md
@@ -5,12 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : LanguageManual SortBy
 
-* [Order, Sort, Cluster, and Distribute By]({{< ref "#order-sort-cluster-and-distribute-by" >}})
-	+ [Syntax of Order By]({{< ref "#syntax-of-order-by" >}})
-	+ [Syntax of Sort By]({{< ref "#syntax-of-sort-by" >}})
-		- [Difference between Sort By and Order By]({{< ref "#difference-between-sort-by-and-order-by" >}})
-		- [Setting Types for Sort By]({{< ref "#setting-types-for-sort-by" >}})
-	+ [Syntax of Cluster By and Distribute By]({{< ref "#syntax-of-cluster-by-and-distribute-by" >}})
+{{< toc >}}
 
 # Order, Sort, Cluster, and Distribute By
 

--- a/content/docs/latest/languagemanual-subqueries_27362044.md
+++ b/content/docs/latest/languagemanual-subqueries_27362044.md
@@ -5,8 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : LanguageManual SubQueries
 
-* [Subqueries in the FROM Clause]({{< ref "#subqueries-in-the-from-clause" >}})
-* [Subqueries in the WHERE Clause]({{< ref "#subqueries-in-the-where-clause" >}})
+{{< toc >}}
 
 # Subqueries in the FROM Clause
 

--- a/content/docs/latest/languagemanual-transform_27362047.md
+++ b/content/docs/latest/languagemanual-transform_27362047.md
@@ -5,11 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : LanguageManual Transform
 
-* [Transform/Map-Reduce Syntax]({{< ref "#transformmap-reduce-syntax" >}})
-	+ [SQL Standard Based Authorization Disallows TRANSFORM]({{< ref "#sql-standard-based-authorization-disallows-transform" >}})
-	+ [TRANSFORM Examples]({{< ref "#transform-examples" >}})
-* [Schema-less Map-reduce Scripts]({{< ref "#schema-less-map-reduce-scripts" >}})
-* [Typing the output of TRANSFORM]({{< ref "#typing-the-output-of-transform" >}})
+{{< toc >}}
 
 ## Transform/Map-Reduce Syntax
 

--- a/content/docs/latest/languagemanual-types_27838462.md
+++ b/content/docs/latest/languagemanual-types_27838462.md
@@ -3,41 +3,9 @@ title: "Apache Hive : LanguageManual Types"
 date: 2024-12-12
 ---
 
-# Apache Hive : LanguageManual Types
+# Apache Hive : LanguageManual Data Types
 
-# Hive Data Types
-
-* [Hive Data Types]({{< ref "#hive-data-types" >}})
-	+ [Overview]({{< ref "#overview" >}})
-		- [Numeric Types]({{< ref "#numeric-types" >}})
-		- [Date/Time Types]({{< ref "#datetime-types" >}})
-		- [String Types]({{< ref "#string-types" >}})
-		- [Misc Types]({{< ref "#misc-types" >}})
-		- [Complex Types]({{< ref "#complex-types" >}})
-	+ [Column Types]({{< ref "#column-types" >}})
-		- [Integral Types (TINYINT, SMALLINT, INT/INTEGER, BIGINT)]({{< ref "#integral-types--tinyint,-smallint,-int/integer,-bigint-" >}})
-		- 
-		- [Strings]({{< ref "#strings" >}})
-		- [Varchar]({{< ref "#varchar" >}})
-		- [Char]({{< ref "#char" >}})
-		- [Timestamps]({{< ref "#timestamps" >}})
-			* [Casting Dates]({{< ref "#casting-dates" >}})
-		- [Intervals]({{< ref "#intervals" >}})
-		- [Decimals]({{< ref "#decimals" >}})
-			* [Decimal Literals]({{< ref "#decimal-literals" >}})
-			* [Decimal Type Incompatibilities between Hive 0.12.0 and 0.13.0]({{< ref "#decimal-type-incompatibilities-between-hive-0120-and-0130" >}})
-				+ [Upgrading Pre-Hive 0.13.0 Decimal Columns]({{< ref "#upgrading-pre-hive-0130-decimal-columns" >}})
-		- [Union Types]({{< ref "#union-types" >}})
-	+ [Literals]({{< ref "#literals" >}})
-		- [Floating Point Types]({{< ref "#floating-point-types" >}})
-			* [Decimal Types]({{< ref "#decimal-types" >}})
-				+ [Using Decimal Types]({{< ref "#using-decimal-types" >}})
-				+ [Mathematical UDFs]({{< ref "#mathematical-udfs" >}})
-				+ [Casting Decimal Values]({{< ref "#casting-decimal-values" >}})
-				+ [Testing Decimal Types]({{< ref "#testing-decimal-types" >}})
-	+ [Handling of NULL Values]({{< ref "#handling-of-null-values" >}})
-	+ [Change Types]({{< ref "#change-types" >}})
-	+ [Allowed Implicit Conversions]({{< ref "#allowed-implicit-conversions" >}})
+{{< toc >}}
 
 ## Overview
 

--- a/content/docs/latest/languagemanual-udf_27362046.md
+++ b/content/docs/latest/languagemanual-udf_27362046.md
@@ -3,49 +3,11 @@ title: "Apache Hive : LanguageManual UDF"
 date: 2024-12-12
 ---
 
-# Apache Hive : LanguageManual UDF
+# Apache Hive : LanguageManual Operators and User-Defined Functions
 
-# Hive Operators and User-Defined Functions (UDFs)
+{{< toc >}}
 
-* [Hive Operators and User-Defined Functions (UDFs)]({{< ref "#hive-operators-and-user-defined-functions-udfs" >}})
-	+ [Built-in Operators]({{< ref "#built-in-operators" >}})
-		- [Operators Precedences]({{< ref "#operators-precedences" >}})
-		- [Relational Operators]({{< ref "#relational-operators" >}})
-		- [Arithmetic Operators]({{< ref "#arithmetic-operators" >}})
-		- [Logical Operators]({{< ref "#logical-operators" >}})
-		- [String Operators]({{< ref "#string-operators" >}})
-		- [Complex Type Constructors]({{< ref "#complex-type-constructors" >}})
-		- [Operators on Complex Types]({{< ref "#operators-on-complex-types" >}})
-	+ [Built-in Functions]({{< ref "#built-in-functions" >}})
-		- [Mathematical Functions]({{< ref "#mathematical-functions" >}})
-			* [Mathematical Functions and Operators for Decimal Datatypes]({{< ref "#mathematical-functions-and-operators-for-decimal-datatypes" >}})
-		- [Collection Functions]({{< ref "#collection-functions" >}})
-		- [Type Conversion Functions]({{< ref "#type-conversion-functions" >}})
-		- [Date Functions]({{< ref "#date-functions" >}})
-		- [Conditional Functions]({{< ref "#conditional-functions" >}})
-		- [String Functions]({{< ref "#string-functions" >}})
-		- [Data Masking Functions]({{< ref "#data-masking-functions" >}})
-		- [Misc. Functions]({{< ref "#misc-functions" >}})
-			* [xpath]({{< ref "#xpath" >}})
-			* [get_json_object]({{< ref "#get_json_object" >}})
-	+ [Built-in Aggregate Functions (UDAF)]({{< ref "#built-in-aggregate-functions-udaf" >}})
-	+ [Built-in Table-Generating Functions (UDTF)]({{< ref "#built-in-table-generating-functions-udtf" >}})
-		- [Usage Examples]({{< ref "#usage-examples" >}})
-			* [explode (array)]({{< ref "#explode--array-" >}})
-			* [explode (map)]({{< ref "#explode--map-" >}})
-			* [posexplode (array)]({{< ref "#posexplode--array-" >}})
-			* [inline (array of structs)]({{< ref "#inline--array-of-structs-" >}})
-			* [stack (values)]({{< ref "#stack--values-" >}})
-		- [explode]({{< ref "#explode" >}})
-		- [posexplode]({{< ref "#posexplode" >}})
-		- [json_tuple]({{< ref "#json_tuple" >}})
-		- [parse_url_tuple]({{< ref "#parse_url_tuple" >}})
-	+ [GROUPing and SORTing on f(column)]({{< ref "#grouping-and-sorting-on-fcolumn" >}})
-	+ [Utility Functions]({{< ref "#utility-functions" >}})
-	+ [UDF internals]({{< ref "#udf-internals" >}})
-	+ [Creating Custom UDFs]({{< ref "#creating-custom-udfs" >}})
-
-Case-insensitive
+## Overview
 
 All Hive keywords are case-insensitive, including the names of Hive operators and functions.
 
@@ -284,13 +246,7 @@ The following built-in date functions are supported in Hive:
 | string | date_format(date/timestamp/string ts, string pattern) | Converts a date/timestamp/string to a value of string using the specified pattern (as of Hive [1.2.0](https://issues.apache.org/jira/browse/HIVE-10276)). The accepted patterns and their behavior depend on the underlying formatter implementation. The pattern argument should be constant. Example: date_format('2015-04-08', 'y') = '2015'.date_format can be used to implement other UDFs, e.g.:* dayname(date) is date_format(date, 'EEEE')
 * dayofyear(date) is date_format(date, 'D')
 
-As of Hive 4.0.0 (
-
-[HIVE-27673](https://issues.apache.org/jira/browse/HIVE-27673?src=confmacro)
- -
- Configurable datetime formatter for date_format
-Closed
-
+As of Hive 4.0.0 ([HIVE-27673](https://issues.apache.org/jira/browse/HIVE-27673)
 ), the "hive.datetime.formatter" property can be used to control the underlying formatter implementation, and as a consequence the accepted patterns and their behavior. Prior versions always used <https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html> as the underlying formatter. |
 
 ### Conditional Functions

--- a/content/docs/latest/languagemanual-union_27362049.md
+++ b/content/docs/latest/languagemanual-union_27362049.md
@@ -5,13 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : LanguageManual Union
 
-* [Union Syntax]({{< ref "#union-syntax" >}})
-	+ [UNION within a FROM Clause]({{< ref "#union-within-a-from-clause" >}})
-	+ [Unions in DDL and Insert Statements]({{< ref "#unions-in-ddl-and-insert-statements" >}})
-	+ [Applying Subclauses]({{< ref "#applying-subclauses" >}})
-	+ [Column Aliases for Schema Matching]({{< ref "#column-aliases-for-schema-matching" >}})
-	+ [Column Type Conversion]({{< ref "#column-type-conversion" >}})
-	+ [Version Information]({{< ref "#version-information" >}})
+{{< toc >}}
 
 ## Union Syntax
 

--- a/content/docs/latest/languagemanual-variablesubstitution_30754722.md
+++ b/content/docs/latest/languagemanual-variablesubstitution_30754722.md
@@ -5,12 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : LanguageManual VariableSubstitution
 
-# 
-* 
-* [Introduction]({{< ref "#introduction" >}})
-* [Using Variables]({{< ref "#using-variables" >}})
-* [Substitution During Query Construction]({{< ref "#substitution-during-query-construction" >}})
-* [Disabling Variable Substitution]({{< ref "#disabling-variable-substitution" >}})
+{{< toc >}}
 
 # Introduction
 

--- a/content/docs/latest/languagemanual-virtualcolumns_27362048.md
+++ b/content/docs/latest/languagemanual-virtualcolumns_27362048.md
@@ -5,8 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : LanguageManual VirtualColumns
 
-* [Virtual Columns]({{< ref "#virtual-columns" >}})
-	+ [Simple Examples]({{< ref "#simple-examples" >}})
+{{< toc >}}
 
 ## Virtual Columns
 

--- a/content/docs/latest/languagemanual-windowingandanalytics_31819589.md
+++ b/content/docs/latest/languagemanual-windowingandanalytics_31819589.md
@@ -5,24 +5,9 @@ date: 2024-12-12
 
 # Apache Hive : LanguageManual WindowingAndAnalytics
 
-# Windowing and Analytics Functions
-
-* [Windowing and Analytics Functions]({{< ref "#windowing-and-analytics-functions" >}})
-	+ [Enhancements to Hive QL]({{< ref "#enhancements-to-hive-ql" >}})
-	+ [Examples]({{< ref "#examples" >}})
-		- [PARTITION BY with one partitioning column, no ORDER BY or window specification]({{< ref "#partition-by-with-one-partitioning-column-no-order-by-or-window-specification" >}})
-		- [PARTITION BY with two partitioning columns, no ORDER BY or window specification]({{< ref "#partition-by-with-two-partitioning-columns-no-order-by-or-window-specification" >}})
-		- [PARTITION BY with one partitioning column, one ORDER BY column, and no window specification]({{< ref "#partition-by-with-one-partitioning-column-one-order-by-column-and-no-window-specification" >}})
-		- [PARTITION BY with two partitioning columns, two ORDER BY columns, and no window specification]({{< ref "#partition-by-with-two-partitioning-columns-two-order-by-columns-and-no-window-specification" >}})
-		- [PARTITION BY with partitioning, ORDER BY, and window specification]({{< ref "#partition-by-with-partitioning-order-by-and-window-specification" >}})
-		- [WINDOW clause]({{< ref "#window-clause" >}})
-		- [LEAD using default 1 row lead and not specifying default value]({{< ref "#lead-using-default-1-row-lead-and-not-specifying-default-value" >}})
-		- [LAG specifying a lag of 3 rows and default value of 0]({{< ref "#lag-specifying-a-lag-of-3-rows-and-default-value-of-0" >}})
-		- [Distinct counting for each partition]({{< ref "#distinct-counting-for-each-partition" >}})
+{{< toc >}}
 
 ## Enhancements to Hive QL
-
-Version
 
 Introduced in Hive version 0.11.
 

--- a/content/docs/latest/listbucketing_27846854.md
+++ b/content/docs/latest/listbucketing_27846854.md
@@ -5,23 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : ListBucketing
 
-* [Goal]({{< ref "#goal" >}})
-	+ [Basic Partitioning]({{< ref "#basic-partitioning" >}})
-	+ [List Bucketing]({{< ref "#list-bucketing" >}})
-	+ [Skewed Table vs. List Bucketing Table]({{< ref "#skewed-table-vs-list-bucketing-table" >}})
-	+ [List Bucketing Validation]({{< ref "#list-bucketing-validation" >}})
-		- [DDL]({{< ref "#ddl" >}})
-		- [DML]({{< ref "#dml" >}})
-		- [Alter Table Concatenate]({{< ref "#alter-table-concatenate" >}})
-	+ [Hive Enhancements]({{< ref "#hive-enhancements" >}})
-		- [Create Table]({{< ref "#create-table" >}})
-		- [Alter Table]({{< ref "#alter-table" >}})
-			* [Alter Table Skewed]({{< ref "#alter-table-skewed" >}})
-			* [Alter Table Not Skewed]({{< ref "#alter-table-not-skewed" >}})
-			* [Alter Table Not Stored as Directories]({{< ref "#alter-table-not-stored-as-directories" >}})
-			* [Alter Table Set Skewed Location]({{< ref "#alter-table-set-skewed-location" >}})
-		- [Design]({{< ref "#design" >}})
-* [Implementation]({{< ref "#implementation" >}})
+{{< toc >}}
 
 # Goal
 

--- a/content/docs/latest/llap_62689557.md
+++ b/content/docs/latest/llap_62689557.md
@@ -5,24 +5,10 @@ date: 2024-12-12
 
 # Apache Hive : LLAP
 
-* [Overview]({{< ref "#overview" >}})
-* [Persistent Daemon]({{< ref "#persistent-daemon" >}})
-* [Execution Engine]({{< ref "#execution-engine" >}})
-* [Query Fragment Execution]({{< ref "#query-fragment-execution" >}})
-* [I/O]({{< ref "#io" >}})
-* [Caching]({{< ref "#caching" >}})
-* [Workload Management]({{< ref "#workload-management" >}})
-* [ACID Support]({{< ref "#acid-support" >}})
-* [Security]({{< ref "#security" >}})
-* [Monitoring]({{< ref "#monitoring" >}})
-* [Web Services]({{< ref "#web-services" >}})
-* [SLIDER on YARN Deployment]({{< ref "#slider-on-yarn-deployment" >}})
-* [LLAP Status]({{< ref "#llap-status" >}})
-* [Resources]({{< ref "#resources" >}})
-
 Live Long And Process (LLAP) functionality was added in Hive 2.0 ([HIVE-7926](https://issues.apache.org/jira/browse/HIVE-7926) and associated tasks). [HIVE-9850](https://issues.apache.org/jira/browse/HIVE-9850) links documentation, features, and issues for this enhancement.
-
 For configuration of LLAP, see the LLAP Section of [Configuration Properties]({{< ref "#configuration-properties" >}}).
+
+{{< toc >}}
 
 ## Overview
 

--- a/content/docs/latest/locking_27362050.md
+++ b/content/docs/latest/locking_27362050.md
@@ -5,14 +5,9 @@ date: 2024-12-12
 
 # Apache Hive : Locking
 
-# Hive Concurrency Model
+{{< toc >}}
 
-* [Hive Concurrency Model]({{< ref "#hive-concurrency-model" >}})
-	+ [Use Cases]({{< ref "#use-cases" >}})
-	+ [Turn Off Concurrency]({{< ref "#turn-off-concurrency" >}})
-	+ [Debugging]({{< ref "#debugging" >}})
-	+ [Configuration]({{< ref "#configuration" >}})
-* [Locking in Hive Transactions]({{< ref "#locking-in-hive-transactions" >}})
+# Hive Concurrency Model
 
 ## Use Cases
 

--- a/content/docs/latest/manual-installation_283118363.md
+++ b/content/docs/latest/manual-installation_283118363.md
@@ -5,24 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : Manual Installation
 
-* [Installing, configuring and running Hive]({{< ref "#installing-configuring-and-running-hive" >}})
-	+ [Prerequisites]({{< ref "#prerequisites" >}})
-	+ [Install the prerequisites]({{< ref "#install-the-prerequisites" >}})
-		- [Java 8]({{< ref "#java-8" >}})
-		- [Maven:]({{< ref "#maven" >}})
-		- [Protobuf]({{< ref "#protobuf" >}})
-		- [Hadoop]({{< ref "#hadoop" >}})
-		- [Tez]({{< ref "#tez" >}})
-	+ [Extra hadoop configurations to make everything working]({{< ref "#extra-hadoop-configurations-to-make-everything-working" >}})
-	+ [Installing Hive from a Tarball]({{< ref "#installing-hive-from-a-tarball" >}})
-	+ [Installing from Source Code]({{< ref "#installing-from-source-code" >}})
-    + [Installing with old version hadoop(greater than or equal 3.1.0)]({{< ref "#installing-with-old-version-hadoopgreater-than-or-equal-310" >}})
-	+ [Next Steps]({{< ref "#next-steps" >}})
-	+ [Beeline CLI]({{< ref "#beeline-cli" >}})
-	+ [Hive Metastore]({{< ref "#hive-metastore" >}})
-	+ [HCatalog and WebHCat]({{< ref "#hcatalog-and-webhcat" >}})
-		- [HCatalog]({{< ref "#hcatalog" >}})
-		- [WebHCat (Templeton)]({{< ref "#webhcat-templeton" >}})
+{{< toc >}}
 
 # Installing, configuring and running Hive
 

--- a/content/docs/latest/mapjoin-and-partition-pruning_34015666.md
+++ b/content/docs/latest/mapjoin-and-partition-pruning_34015666.md
@@ -5,14 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : MapJoin and Partition Pruning
 
-* [Overview]({{< ref "#overview" >}})
-	+ [Problem]({{< ref "#problem" >}})
-	+ [Proposed Solution]({{< ref "#proposed-solution" >}})
-	+ [Possible Extensions]({{< ref "#possible-extensions" >}})
-* [Optimization Details]({{< ref "#optimization-details" >}})
-	+ [Compile Time]({{< ref "#compile-time" >}})
-	+ [Runtime]({{< ref "#runtime" >}})
-	+ [Pseudo Code]({{< ref "#pseudo-code" >}})
+{{< toc >}}
 
 # Overview
 

--- a/content/docs/latest/mapjoinoptimization_27362029.md
+++ b/content/docs/latest/mapjoinoptimization_27362029.md
@@ -5,17 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : MapJoinOptimization
 
-**Index** 
-
-* [1. Map Join Optimization]({{< ref "#1-map-join-optimization" >}})
-	+ [1.1 Using Distributed Cache to Propagate Hashtable File]({{< ref "#11-using-distributed-cache-to-propagate-hashtable-file" >}})
-	+ [1.2 Removing JDBM]({{< ref "#12-removing-jdbm" >}})
-	+ [1.3 Performance Evaluation]({{< ref "#13-performance-evaluation" >}})
-* [2. Converting Join into Map Join Automatically]({{< ref "#2-converting-join-into-map-join-automatically" >}})
-	+ [2.1 New Join Execution Flow]({{< ref "#21-new-join-execution-flow" >}})
-	+ [2.2 Resolving the Join Operation at Run Time]({{< ref "#22-resolving-the-join-operation-at-run-time" >}})
-	+ [2.3 Backup Task]({{< ref "#23-backup-task" >}})
-	+ [2.4 Performance Evaluation]({{< ref "#24-performance-evaluation" >}})
+{{< toc >}}
 
 # 1. Map Join Optimization
 

--- a/content/docs/latest/materialized-views_80447331.md
+++ b/content/docs/latest/materialized-views_80447331.md
@@ -5,28 +5,13 @@ date: 2024-12-12
 
 # Apache Hive : Materialized views
 
-* [Introduction]({{< ref "#introduction" >}})
-	+ [Objectives]({{< ref "#objectives" >}})
-* [Management of materialized views in Hive]({{< ref "#management-of-materialized-views-in-hive" >}})
-	+ [Materialized views creation]({{< ref "#materialized-views-creation" >}})
-	+ [Other operations for materialized view management]({{< ref "#other-operations-for-materialized-view-management" >}})
-* [Materialized view-based query rewriting]({{< ref "#materialized-view-based-query-rewriting" >}})
-	+ [Example 1]({{< ref "#example-1" >}})
-	+ [Example 2]({{< ref "#example-2" >}})
-	+ [Example 3]({{< ref "#example-3" >}})
-* [Materialized view maintenance]({{< ref "#materialized-view-maintenance" >}})
-* [Materialized view lifecycle]({{< ref "#materialized-view-lifecycle" >}})
-* [Open issues (JIRA)]({{< ref "#open-issues-jira" >}})
+This page documents the work done for the supporting materialized views in Apache Hive.
 
-  
+{{< toc >}}
 
-Version information
+## Version information
 
 Materialized views support is introduced in Hive 3.0.0.
-
-## Introduction
-
-This page documents the work done for the supporting materialized views in Apache Hive.
 
 ### Objectives
 

--- a/content/docs/latest/parquet_38570914.md
+++ b/content/docs/latest/parquet_38570914.md
@@ -5,25 +5,9 @@ date: 2024-12-12
 
 # Apache Hive : Parquet
 
-Version
-
 Parquet is supported by a plugin in Hive 0.10, 0.11, and 0.12 and natively in Hive 0.13 and later.
 
- 
-
-* [Introduction]({{< ref "#introduction" >}})
-* [Native Parquet Support]({{< ref "#native-parquet-support" >}})
-	+ [Hive 0.10, 0.11, and 0.12]({{< ref "#hive-010-011-and-012" >}})
-	+ [Hive 0.13]({{< ref "#hive-013" >}})
-* [HiveQL Syntax]({{< ref "#hiveql-syntax" >}})
-	+ [Hive 0.10 - 0.12]({{< ref "#hive-010---012" >}})
-	+ [Hive 0.13 and later]({{< ref "#hive-013-and-later" >}})
-* [Versions and Limitations]({{< ref "#versions-and-limitations" >}})
-	+ [Hive 0.13.0]({{< ref "#hive-0130" >}})
-	+ [Hive 0.14.0]({{< ref "#hive-0140" >}})
-	+ [Hive 1.1.0]({{< ref "#hive-110" >}})
-	+ [Hive 1.2.0]({{< ref "#hive-120" >}})
-	+ [Resources]({{< ref "#resources" >}})
+{{< toc >}}
 
 ## **Introduction**
 

--- a/content/docs/latest/partitionedviews_27362053.md
+++ b/content/docs/latest/partitionedviews_27362053.md
@@ -5,15 +5,9 @@ date: 2024-12-12
 
 # Apache Hive : PartitionedViews
 
-* [Use Cases]({{< ref "#use-cases" >}})
-	+ [Approaches]({{< ref "#approaches" >}})
-	+ [Syntax]({{< ref "#syntax" >}})
-	+ [Metastore]({{< ref "#metastore" >}})
-	+ [Strict Mode]({{< ref "#strict-mode" >}})
-	+ [View Definition Changes]({{< ref "#view-definition-changes" >}})
-* [Hook Information]({{< ref "#hook-information" >}})
-
 This is a followup to [ViewDev]({{< ref "viewdev_27362067" >}}) for adding partition-awareness to views.
+
+{{< toc >}}
 
 # Use Cases
 

--- a/content/docs/latest/presentations_27362054.md
+++ b/content/docs/latest/presentations_27362054.md
@@ -5,20 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : Presentations
 
- 
-
-* [Hive Meetups]({{< ref "#hive-meetups" >}})
-	+ [January 2016 Hive User Group Meetup]({{< ref "#january-2016-hive-user-group-meetup" >}})
-	+ [November 2015 Hive Contributor Meetup]({{< ref "#november-2015-hive-contributor-meetup" >}})
-	+ [April 2015 Hive Contributor Meetup Presentations]({{< ref "#april-2015-hive-contributor-meetup-presentations" >}})
-	+ [February 2015 Hive User Meetup Presentation]({{< ref "#february-2015-hive-user-meetup-presentation" >}})
-	+ [November 2013 Hive Contributors Meetup Presentations]({{< ref "#november-2013-hive-contributors-meetup-presentations" >}})
-	+ [June 2013 Hadoop Summit Hive Meetup Presentations]({{< ref "#june-2013-hadoop-summit-hive-meetup-presentations" >}})
-	+ [February 2013 Hive User Group Meetup]({{< ref "#february-2013-hive-user-group-meetup" >}})
-	+ [June 2012 Hadoop Summit Hive Meetup Presentations]({{< ref "#june-2012-hadoop-summit-hive-meetup-presentations" >}})
-	+ [November 2011 NYC Hive Meetup Presentations]({{< ref "#november-2011-nyc-hive-meetup-presentations" >}})
-* [Older Hive Presentations]({{< ref "#older-hive-presentations" >}})
-* [Related Work]({{< ref "#related-work" >}})
+{{< toc >}}
 
 # Hive Meetups
 

--- a/content/docs/latest/query-reexecution_87298873.md
+++ b/content/docs/latest/query-reexecution_87298873.md
@@ -5,17 +5,9 @@ date: 2024-12-12
 
 # Apache Hive : Query ReExecution
 
-Query reexecution provides a facility to re-run the query multiple times in case of an unfortunate event happens.
+Query reexecution provides a facility to re-run the query multiple times in case of an unfortunate event happens. Introduced in Hive 3.0 ([HIVE-17626](https://issues.apache.org/jira/browse/HIVE-17626))
 
-* [ReExecition strategies]({{< ref "#reexecition-strategies" >}})
-	+ [Overlay]({{< ref "#overlay" >}})
-	+ [Reoptimize]({{< ref "#reoptimize" >}})
-	+ [Operator Matching]({{< ref "#operator-matching" >}})
-* [Configuration]({{< ref "#configuration" >}})
-
-  
-
-Introduced in Hive 3.0 ([HIVE-17626](https://issues.apache.org/jira/browse/HIVE-17626))
+{{< toc >}}
 
 # ReExecition strategies
 

--- a/content/docs/latest/rcfilecat_30748712.md
+++ b/content/docs/latest/rcfilecat_30748712.md
@@ -5,13 +5,9 @@ date: 2024-12-12
 
 # Apache Hive : RCFileCat
 
-# RCFileCat
-
-* [RCFileCat]({{< ref "#rcfilecat" >}})
-	+ [Data]({{< ref "#data" >}})
-	+ [Metadata]({{< ref "#metadata" >}})
-
 $HIVE_HOME/bin/hive --rcfilecat is a shell utility which can be used to print data or metadata from [RC files]({{< ref "rcfile_58851803" >}}).
+
+{{< toc >}}
 
 ## Data
 

--- a/content/docs/latest/replacing-the-implementation-of-hive-cli-using-beeline_61311909.md
+++ b/content/docs/latest/replacing-the-implementation-of-hive-cli-using-beeline_61311909.md
@@ -5,15 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : Replacing the Implementation of Hive CLI Using Beeline
 
-## 
-* 
-* [Why Replace the Existing Hive CLI?]({{< ref "#why-replace-the-existing-hive-cli" >}})
-* [Hive CLI Functionality Support]({{< ref "#hive-cli-functionality-support" >}})
-	+ [Hive CLI Options Support]({{< ref "#hive-cli-options-support" >}})
-	+ [Examples]({{< ref "#examples" >}})
-	+ [Hive CLI Interactive Shell Commands Support]({{< ref "#hive-cli-interactive-shell-commands-support" >}})
-	+ [Hive CLI Configuration Support]({{< ref "#hive-cli-configuration-support" >}})
-* [Performance Impacts]({{< ref "#performance-impacts" >}})
+{{< toc >}}
 
 ## Why Replace the Existing Hive CLI?
 

--- a/content/docs/latest/replication_61336919.md
+++ b/content/docs/latest/replication_61336919.md
@@ -5,13 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : Replication
 
-* [Overview]({{< ref "#overview" >}})
-* [Potential Uses]({{< ref "#potential-uses" >}})
-* [Prerequisites]({{< ref "#prerequisites" >}})
-* [Limitations]({{< ref "#limitations" >}})
-* [Configuration]({{< ref "#configuration" >}})
-* [Typical Mode of Operation]({{< ref "#typical-mode-of-operation" >}})
-* [Replication to AWS/EMR/S3]({{< ref "#replication-to-awsemrs3" >}})
+{{< toc >}}
 
 ## Overview
 

--- a/content/docs/latest/scheduled-queries_145724128.md
+++ b/content/docs/latest/scheduled-queries_145724128.md
@@ -5,32 +5,9 @@ date: 2024-12-12
 
 # Apache Hive : Scheduled Queries
 
- 
-* [Maintaining scheduled queries]({{< ref "#maintaining-scheduled-queries" >}})
-	+ [Create Scheduled query syntax]({{< ref "#create-scheduled-query-syntax" >}})
-	+ [Alter Scheduled query syntax]({{< ref "#alter-scheduled-query-syntax" >}})
-	+ [Drop syntax]({{< ref "#drop-syntax" >}})
-	+ [scheduleSpecification syntax]({{< ref "#schedulespecification-syntax" >}})
-		- [CRON based schedule syntax]({{< ref "#cron-based-schedule-syntax" >}})
-		- [EVERY based schedule syntax]({{< ref "#every-based-schedule-syntax" >}})
-	+ [ExecutedAs syntax]({{< ref "#executedas-syntax" >}})
-	+ [enableSpecification syntax]({{< ref "#enablespecification-syntax" >}})
-	+ [Defined AS syntax]({{< ref "#defined-as-syntax" >}})
-	+ [executeSpec syntax]({{< ref "#executespec-syntax" >}})
-* [System tables/views]({{< ref "#system-tablesviews" >}})
-	+ [information_schema.scheduled_queries]({{< ref "#information_schemascheduled_queries" >}})
-	+ [information_schema.scheduled_executions]({{< ref "#information_schemascheduled_executions" >}})
-		- [Execution states]({{< ref "#execution-states" >}})
-* [Configuration]({{< ref "#configuration" >}})
-	+ [Hive metastore related configuration]({{< ref "#hive-metastore-related-configuration" >}})
-	+ [HiveServer2 related configuration]({{< ref "#hiveserver2-related-configuration" >}})
-* [Examples]({{< ref "#examples" >}})
-	+ [Example 1 – basic example of using schedules]({{< ref "#example-1-–-basic-example-of-using-schedules" >}})
-	+ [Example 2 – analyze external table periodically]({{< ref "#example-2-–-analyze-external-table-periodically" >}})
-	+ [Example 3 – materialized view rebuild]({{< ref "#example-3-–-materialized-view-rebuild" >}})
-	+ [Example 4 – Ingestion]({{< ref "#example-4-–-ingestion" >}})
+{{< toc >}}
 
-**Intro**
+# Introduction
 
 Executing statements periodically can be usefull in
 

--- a/content/docs/latest/serde_27362059.md
+++ b/content/docs/latest/serde_27362059.md
@@ -5,14 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : SerDe
 
-* [SerDe Overview]({{< ref "#serde-overview" >}})
-	+ [Built-in and Custom SerDes]({{< ref "#built-in-and-custom-serdes" >}})
-		- [Built-in SerDes]({{< ref "#built-in-serdes" >}})
-		- [Custom SerDes]({{< ref "#custom-serdes" >}})
-	+ [HiveQL for SerDes]({{< ref "#hiveql-for-serdes" >}})
-* [Input Processing]({{< ref "#input-processing" >}})
-* [Output Processing]({{< ref "#output-processing" >}})
-* [Additional Notes]({{< ref "#additional-notes" >}})
+{{< toc >}}
 
 # SerDe Overview
 

--- a/content/docs/latest/setting-up-hiveserver2_30758712.md
+++ b/content/docs/latest/setting-up-hiveserver2_30758712.md
@@ -5,33 +5,6 @@ date: 2024-12-12
 
 # Apache Hive : Setting Up HiveServer2
 
-# HiveServer2
-
-* [HiveServer2]({{< ref "#hiveserver2" >}})
-	+ [How to Configure]({{< ref "#how-to-configure" >}})
-		- [Configuration Properties in the hive-site.xml File]({{< ref "#configuration-properties-in-the-hive-site-xml-file" >}})
-		- [Running in HTTP Mode]({{< ref "#running-in-http-mode" >}})
-			* [Cookie Based Authentication]({{< ref "#cookie-based-authentication" >}})
-		- [Optional Global Init File]({{< ref "#optional-global-init-file" >}})
-		- [Logging Configuration]({{< ref "#logging-configuration" >}})
-	+ [How to Start]({{< ref "#how-to-start" >}})
-		- [Usage Message]({{< ref "#usage-message" >}})
-	+ [Authentication/Security Configuration]({{< ref "#authenticationsecurity-configuration" >}})
-		- [Configuration]({{< ref "#configuration" >}})
-		- [Impersonation]({{< ref "#impersonation" >}})
-		- [Integrity/Confidentiality Protection]({{< ref "#integrity/confidentiality-protection" >}})
-		- [SSL Encryption]({{< ref "#ssl-encryption" >}})
-			* [Setting up SSL with self-signed certificates]({{< ref "#setting-up-ssl-with-self-signed-certificates" >}})
-			* [Selectively disabling SSL protocol versions]({{< ref "#selectively-disabling-ssl-protocol-versions" >}})
-		- [Pluggable Authentication Modules (PAM)]({{< ref "#pluggable-authentication-modules--pam-" >}})
-		- [Setting up HiveServer2 job credential provider]({{< ref "#setting-up-hiveserver2-job-credential-provider" >}})
-	+ [Scratch Directory Management]({{< ref "#scratch-directory-management" >}})
-		- [Configuration Properties]({{< ref "#configuration-properties" >}})
-		- [ClearDanglingScratchDir Tool]({{< ref "#cleardanglingscratchdir-tool" >}})
-	+ [Web UI for HiveServer2]({{< ref "#web-ui-for-hiveserver2" >}})
-	+ [Python Client Driver]({{< ref "#python-client-driver" >}})
-	+ [Ruby Client Driver]({{< ref "#ruby-client-driver" >}})
-
 [HiveServer2](https://cwiki.apache.org/confluence/display/Hive/HiveServer2+Overview) (HS2) is a server interface that enables remote clients to execute queries against Hive and retrieve the results (a more detailed intro [here](https://cwiki.apache.org/confluence/display/Hive/HiveServer2+Overview)). The current implementation, based on Thrift RPC, is an improved version of [HiveServer]({{< ref "hiveserver_27362111" >}}) and supports multi-client concurrency and authentication. It is designed to provide better support for open API clients like JDBC and ODBC.
 
 * The Thrift interface definition language (IDL) for HiveServer2 is available at <https://github.com/apache/hive/blob/trunk/service/if/TCLIService.thrift>.
@@ -39,7 +12,9 @@ date: 2024-12-12
 
 This document describes how to set up the server. How to use a client with this server is described in the [HiveServer2 Clients document]({{< ref "hiveserver2-clients_30758725" >}}).
 
-Version
+{{< toc >}}
+
+## Version information
 
 Introduced in Hive version 0.11. See [HIVE-2935](https://issues.apache.org/jira/browse/HIVE-2935).
 

--- a/content/docs/latest/sql-standard-based-hive-authorization_40509928.md
+++ b/content/docs/latest/sql-standard-based-hive-authorization_40509928.md
@@ -5,29 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : SQL Standard Based Hive Authorization
 
-  
-
-* [Status of Hive Authorization before Hive 0.13]({{< ref "#status-of-hive-authorization-before-hive-013" >}})
-* [SQL Standards Based Hive Authorization (New in Hive 0.13)]({{< ref "#sql-standards-based-hive-authorization--new-in-hive-0-13-" >}})
-	+ [Restrictions on Hive Commands and Statements]({{< ref "#restrictions-on-hive-commands-and-statements" >}})
-	+ [Privileges]({{< ref "#privileges" >}})
-	+ [Objects]({{< ref "#objects" >}})
-	+ [Object Ownership]({{< ref "#object-ownership" >}})
-	+ [Users and Roles]({{< ref "#users-and-roles" >}})
-		- [Names of Users and Roles]({{< ref "#names-of-users-and-roles" >}})
-		- [Role Management Commands]({{< ref "#role-management-commands" >}})
-	+ [Managing Object Privileges]({{< ref "#managing-object-privileges" >}})
-		- [Object Privilege Commands]({{< ref "#object-privilege-commands" >}})
-		- [Examples of Managing Object Privileges]({{< ref "#examples-of-managing-object-privileges" >}})
-	+ [Privileges Required for Hive Operations]({{< ref "#privileges-required-for-hive-operations" >}})
-	+ [Configuration]({{< ref "#configuration" >}})
-		- [For Hive 0.13.x]({{< ref "#for-hive-013x" >}})
-		- [For Hive 0.14 and Newer]({{< ref "#for-hive-014-and-newer" >}})
-	+ [Known Issues]({{< ref "#known-issues" >}})
-		- [Hive 0.13]({{< ref "#hive-013" >}})
-		- [Hive 0.13.1]({{< ref "#hive-0131" >}})
-	+ [References]({{< ref "#references" >}})
-	+ [Troubleshooting]({{< ref "#troubleshooting" >}})
+{{< toc >}}
 
 # Status of Hive Authorization before Hive 0.13
 

--- a/content/docs/latest/statisticsanddatamining_27362058.md
+++ b/content/docs/latest/statisticsanddatamining_27362058.md
@@ -3,21 +3,11 @@ title: "Apache Hive : StatisticsAndDataMining"
 date: 2024-12-12
 ---
 
-# Apache Hive : StatisticsAndDataMining
-
-# Statistics and Data Mining in Hive
+# Apache Hive : Statistics and Data Mining
 
 This page is the secondary documentation for the slightly more advanced statistical and data mining functions that are being integrated into Hive, and especially the functions that warrant more than one-line descriptions. 
 
-* [Statistics and Data Mining in Hive]({{< ref "#statistics-and-data-mining-in-hive" >}})
-	+ [ngrams() and context_ngrams(): N-gram frequency estimation]({{< ref "#ngrams-and-context_ngrams-n-gram-frequency-estimation" >}})
-		- [Use Cases]({{< ref "#use-cases" >}})
-		- [Usage]({{< ref "#usage" >}})
-		- [Example]({{< ref "#example" >}})
-	+ [histogram_numeric(): Estimating frequency distributions]({{< ref "#histogram_numeric-estimating-frequency-distributions" >}})
-		- [Use Cases]({{< ref "#use-cases" >}})
-		- [Usage]({{< ref "#usage" >}})
-		- [Example]({{< ref "#example" >}})
+{{< toc >}}
 
 ## ngrams() and context_ngrams(): N-gram frequency estimation
 

--- a/content/docs/latest/statsdev_27362062.md
+++ b/content/docs/latest/statsdev_27362062.md
@@ -3,27 +3,11 @@ title: "Apache Hive : StatsDev"
 date: 2024-12-12
 ---
 
-# Apache Hive : StatsDev
-
-# Statistics in Hive
-
-* [Statistics in Hive]({{< ref "#statistics-in-hive" >}})
-	+ [Motivation]({{< ref "#motivation" >}})
-	+ [Scope]({{< ref "#scope" >}})
-		- [Table and Partition Statistics]({{< ref "#table-and-partition-statistics" >}})
-		- [Column Statistics]({{< ref "#column-statistics" >}})
-		- [Top K Statistics]({{< ref "#top-k-statistics" >}})
-	+ [Quick overview]({{< ref "#quick-overview" >}})
-	+ [Implementation]({{< ref "#implementation" >}})
-	+ [Usage]({{< ref "#usage" >}})
-		- [Configuration Variables]({{< ref "#configuration-variables" >}})
-		- [Newly Created Tables]({{< ref "#newly-created-tables" >}})
-		- [Existing Tables – ANALYZE]({{< ref "#existing-tables-–-analyze" >}})
-	+ [Examples]({{< ref "#examples" >}})
-		- [ANALYZE TABLE <table1> CACHE METADATA]({{< ref "#analyze-table-table1-cache-metadata" >}})
-	+ [Current Status (JIRA)]({{< ref "#current-status-jira" >}})
+# Apache Hive : Statistics
 
 This document describes the support of statistics for Hive tables (see [HIVE-33](http://issues.apache.org/jira/browse/HIVE-33)).
+
+{{< toc >}}
 
 ## Motivation
 

--- a/content/docs/latest/storage-based-authorization-in-the-metastore-server_45876440.md
+++ b/content/docs/latest/storage-based-authorization-in-the-metastore-server_45876440.md
@@ -5,24 +5,14 @@ date: 2024-12-12
 
 # Apache Hive : Storage Based Authorization in the Metastore Server
 
-* [Storage Based Authorization in the Metastore Server]({{< ref "#storage-based-authorization-in-the-metastore-server" >}})
-	+ [The Need for Metastore Server Security]({{< ref "#the-need-for-metastore-server-security" >}})
-	+ [Storage Based Authorization]({{< ref "#storage-based-authorization" >}})
-	+ [Configuration Parameters for Metastore Security]({{< ref "#configuration-parameters-for-metastore-security" >}})
-		- [Sample hive-site.xml: Default Settings]({{< ref "#sample-hive-site-xml:-default-settings" >}})
-
-  
-
-# Storage Based Authorization in the Metastore Server
-
 The metastore server security feature with storage based authorization was added to Hive in release 0.10. This feature was introduced previously in [HCatalog]({{< ref "hcatalog-authorization_34014782" >}}).
-
-Version 0.10.0
 
 [HIVE-3705](https://issues.apache.org/jira/browse/HIVE-3705) added metastore server security to Hive in release 0.10.0.
 
 * For additional information about storage based authorization in the metastore server, see the HCatalog document [Storage Based Authorization]({{< ref "hcatalog-authorization_34014782" >}}).
 * For an overview of Hive authorization models and other security options, see the [Authorization]({{< ref "languagemanual-authorization_27362032" >}}) document.
+
+{{< toc >}}
 
 ## The Need for Metastore Server Security
 

--- a/content/docs/latest/streaming-data-ingest-v2_85477610.md
+++ b/content/docs/latest/streaming-data-ingest-v2_85477610.md
@@ -7,23 +7,7 @@ date: 2024-12-12
 
 Starting in release Hive 3.0.0, [Streaming Data Ingest]({{< ref "streaming-data-ingest_40509746" >}}) is deprecated and is replaced by newer V2 API ([HIVE-19205](https://issues.apache.org/jira/browse/HIVE-19205)). 
 
-* [Hive Streaming API]({{< ref "#hive-streaming-api" >}})
-	+ [Streaming Mutation API Deprecation and Removal]({{< ref "#streaming-mutation-api-deprecation-and-removal" >}})
-* [Streaming Requirements]({{< ref "#streaming-requirements" >}})
-* [Limitations]({{< ref "#limitations" >}})
-* [API Usage]({{< ref "#api-usage" >}})
-	+ [Transaction and Connection Management]({{< ref "#transaction-and-connection-management" >}})
-		- [HiveStreamingConnection]({{< ref "#hivestreamingconnection" >}})
-			* [Usage Guidelines]({{< ref "#usage-guidelines" >}})
-		- [Notes about the HiveConf Object]({{< ref "#notes-about-the-hiveconf-object" >}})
-	+ [I/O – Writing Data]({{< ref "#io--writing-data" >}})
-		- [RecordWriter]({{< ref "#recordwriter" >}})
-		- [StrictDelimitedInputWriter]({{< ref "#strictdelimitedinputwriter" >}})
-		- [StrictJsonWriter]({{< ref "#strictjsonwriter" >}})
-		- [StrictRegexWriter]({{< ref "#strictregexwriter" >}})
-		- [AbstractRecordWriter]({{< ref "#abstractrecordwriter" >}})
-	+ [Error Handling]({{< ref "#error-handling" >}})
-* [Example]({{< ref "#example" >}})
+{{< toc >}}
 
 # Hive Streaming API
 

--- a/content/docs/latest/streaming-data-ingest_40509746.md
+++ b/content/docs/latest/streaming-data-ingest_40509746.md
@@ -5,28 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : Streaming Data Ingest
 
-* [Hive 3 Streaming API]({{< ref "#hive-3-streaming-api" >}})
-* [Hive HCatalog Streaming API]({{< ref "#hive-hcatalog-streaming-api" >}})
-	+ [Streaming Mutation API]({{< ref "#streaming-mutation-api" >}})
-* [Streaming Requirements]({{< ref "#streaming-requirements" >}})
-* [Limitations]({{< ref "#limitations" >}})
-* [API Usage]({{< ref "#api-usage" >}})
-	+ [Transaction and Connection Management]({{< ref "#transaction-and-connection-management" >}})
-		- [HiveEndPoint]({{< ref "#hiveendpoint" >}})
-		- [StreamingConnection]({{< ref "#streamingconnection" >}})
-		- [TransactionBatch]({{< ref "#transactionbatch" >}})
-			* [Usage Guidelines]({{< ref "#usage-guidelines" >}})
-		- [Notes about the HiveConf Object]({{< ref "#notes-about-the-hiveconf-object" >}})
-	+ [I/O – Writing Data]({{< ref "#io--writing-data" >}})
-		- [RecordWriter]({{< ref "#recordwriter" >}})
-		- [DelimitedInputWriter]({{< ref "#delimitedinputwriter" >}})
-		- [StrictJsonWriter]({{< ref "#strictjsonwriter" >}})
-		- [StrictRegexWriter]({{< ref "#strictregexwriter" >}})
-		- [AbstractRecordWriter]({{< ref "#abstractrecordwriter" >}})
-	+ [Error Handling]({{< ref "#error-handling" >}})
-* [Example – Non-secure Mode]({{< ref "#example-–-non-secure-mode" >}})
-* [Example – Secure Streaming]({{< ref "#example-–-secure-streaming" >}})
-* [Knowledge Base]({{< ref "#knowledge-base" >}})
+{{< toc >}}
 
 # Hive 3 Streaming API
 

--- a/content/docs/latest/teradatabinaryserde_89068127.md
+++ b/content/docs/latest/teradatabinaryserde_89068127.md
@@ -5,19 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : TeradataBinarySerde
 
-* [Availability]({{< ref "#availability" >}})
-* [Overview]({{< ref "#overview" >}})
-* [How to export]({{< ref "#how-to-export" >}})
-	+ [Using TPT FastExport]({{< ref "#using-tpt-fastexport" >}})
-	+ [Using BTEQ]({{< ref "#using-bteq" >}})
-* [How to import]({{< ref "#how-to-import" >}})
-	+ [Using BTEQ]({{< ref "#using-bteq" >}})
-	+ [Using TPT FastLoad]({{< ref "#using-tpt-fastload" >}})
-* [Usage]({{< ref "#usage" >}})
-	+ [Table Creating]({{< ref "#table-creating" >}})
-	+ [Table Properties]({{< ref "#table-properties" >}})
-	+ [Teradata to Hive Type Conversion]({{< ref "#teradata-to-hive-type-conversion" >}})
-	+ [Serde Restriction]({{< ref "#serde-restriction" >}})
+{{< toc >}}
 
 ### Availability
 

--- a/content/docs/latest/theta-join_33293991.md
+++ b/content/docs/latest/theta-join_33293991.md
@@ -5,25 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : Theta Join
 
-* [Preliminaries]({{< ref "#preliminaries" >}})
-	+ [Overview]({{< ref "#overview" >}})
-	+ [Specific Use Cases]({{< ref "#specific-use-cases" >}})
-		- [Geo-Location]({{< ref "#geo-location" >}})
-		- [Side-Table Similarity]({{< ref "#side-table-similarity" >}})
-	+ [Requirements]({{< ref "#requirements" >}})
-		- [Goals]({{< ref "#goals" >}})
-		- [Specific Non-Goals]({{< ref "#specific-non-goals" >}})
-* [Literature Review]({{< ref "#literature-review" >}})
-	+ [Map-Reduce-Merge: Simplified Relational Data Processing on Large Clusters [1]]({{< ref "#map-reduce-merge:-simplified-relational-data-processing-on-large-clusters-[1]" >}})
-	+ [Efficient Parallel Set-Similarity Joins Using MapReduce [2]]({{< ref "#efficient-parallel-set-similarity-joins-using-mapreduce-[2]" >}})
-	+ [Processing Theta-Joins using MapReduce [3]]({{< ref "#processing-theta-joins-using-mapreduce-[3]" >}})
-	+ [Efficient Multi-way Theta-Join Processing Using MapReduce [4]]({{< ref "#efficient-multi-way-theta-join-processing-using-mapreduce-[4]" >}})
-* [Design]({{< ref "#design" >}})
-	+ [Map-side]({{< ref "#map-side" >}})
-	+ [Reduce-side]({{< ref "#reduce-side" >}})
-		- [Mapper]({{< ref "#mapper" >}})
-		- [Reducer]({{< ref "#reducer" >}})
-* [References]({{< ref "#references" >}})
+{{< toc >}}
 
 ## Preliminaries
 

--- a/content/docs/latest/top-k-stats_30150275.md
+++ b/content/docs/latest/top-k-stats_30150275.md
@@ -3,20 +3,11 @@ title: "Apache Hive : Top K Stats"
 date: 2024-12-12
 ---
 
-# Apache Hive : Top K Stats
-
-# Column Level Top K Statistics
-
-* [Column Level Top K Statistics]({{< ref "#column-level-top-k-statistics" >}})
-	+ [Scope]({{< ref "#scope" >}})
-	+ [Implementation]({{< ref "#implementation" >}})
-	+ [Usage]({{< ref "#usage" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Newly Created Tables]({{< ref "#newly-created-tables" >}})
-		- [Existing Tables]({{< ref "#existing-tables" >}})
-	+ [Current Status (JIRA)]({{< ref "#current-status-jira" >}})
-
+# Apache Hive : Column Level Top K Statistics
+	
 This document is an addition to [Statistics in Hive](https://cwiki.apache.org/confluence/display/Hive/StatsDev). It describes the support of collecting column level top K values for Hive tables (see [HIVE-3421](https://issues.apache.org/jira/browse/HIVE-3421)).
+
+{{< toc >}}
 
 ## Scope
 

--- a/content/docs/latest/tutorial_27362061.md
+++ b/content/docs/latest/tutorial_27362061.md
@@ -5,20 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : Tutorial
 
-# **Hive Tutorial**
-
----
-
-* [Hive Tutorial]({{< ref "#hive-tutorial" >}})
-* [Concepts]({{< ref "#concepts" >}})
-	+ [What Is Hive]({{< ref "#what-is-hive" >}})
-	+ [What Hive Is NOT]({{< ref "#what-hive-is-not" >}})
-	+ [Getting Started]({{< ref "#getting-started" >}})
-	+ [Data Units]({{< ref "#data-units" >}})
-	+ [Type System]({{< ref "#type-system" >}})
-	+ [Built In Operators and Functions]({{< ref "#built-in-operators-and-functions" >}})
-	+ [Language Capabilities]({{< ref "#language-capabilities" >}})
-* [Usage and Examples]({{< ref "#usage-and-examples" >}})
+{{< toc >}}
 
 # Concepts
 

--- a/content/docs/latest/unit-testing-hive-sql_61328063.md
+++ b/content/docs/latest/unit-testing-hive-sql_61328063.md
@@ -5,15 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : Unit Testing Hive SQL
 
-* [Motivations]({{< ref "#motivations" >}})
-* [Challenges]({{< ref "#challenges" >}})
-* [Modularisation]({{< ref "#modularisation" >}})
-	+ [Encapsulation of column level logic]({{< ref "#encapsulation-of-column-level-logic" >}})
-	+ [Encapsulation of set level logic]({{< ref "#encapsulation-of-set-level-logic" >}})
-* [Tools and frameworks]({{< ref "#tools-and-frameworks" >}})
-* [Useful practices]({{< ref "#useful-practices" >}})
-* [Relevant issues]({{< ref "#relevant-issues" >}})
-* [Other Hive unit testing concerns]({{< ref "#other-hive-unit-testing-concerns" >}})
+{{< toc >}}
 
 # Motivations
 

--- a/content/docs/latest/user-and-group-filter-support-with-ldap-atn-provider-in-hiveserver2_58852417.md
+++ b/content/docs/latest/user-and-group-filter-support-with-ldap-atn-provider-in-hiveserver2_58852417.md
@@ -5,19 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : User and Group Filter Support with LDAP Atn Provider in HiveServer2
 
-* [User and Group Filter Support with LDAP]({{< ref "#user-and-group-filter-support-with-ldap" >}})
-	+ [Group Membership]({{< ref "#group-membership" >}})
-		- [hive.server2.authentication.ldap.groupDNPattern]({{< ref "#hiveserver2authenticationldapgroupdnpattern" >}})
-		- [hive.server2.authentication.ldap.groupFilter]({{< ref "#hiveserver2authenticationldapgroupfilter" >}})
-		- [hive.server2.authentication.ldap.groupMembershipKey]({{< ref "#hiveserver2authenticationldapgroupmembershipkey" >}})
-		- [hive.server2.authentication.ldap.groupClassKey]({{< ref "#hiveserver2authenticationldapgroupclasskey" >}})
-	+ [User Search List]({{< ref "#user-search-list" >}})
-		- [hive.server2.authentication.ldap.userDNPattern]({{< ref "#hiveserver2authenticationldapuserdnpattern" >}})
-		- [hive.server2.authentication.ldap.userFilter]({{< ref "#hiveserver2authenticationldapuserfilter" >}})
-	+ [Custom Query String]({{< ref "#custom-query-string" >}})
-		- [hive.server2.authentication.ldap.customLDAPQuery]({{< ref "#hiveserver2authenticationldapcustomldapquery" >}})
-		- [Support for Groups in Custom LDAP Query]({{< ref "#support-for-groups-in-custom-ldap-query" >}})
-	+ [Order of Precedence]({{< ref "#order-of-precedence" >}})
+{{< toc >}}
 
 ## User and Group Filter Support with LDAP
 

--- a/content/docs/latest/user-faq_27362095.md
+++ b/content/docs/latest/user-faq_27362095.md
@@ -5,37 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : User FAQ
 
-# Hive User FAQ
-
-* [Hive User FAQ]({{< ref "#hive-user-faq" >}})
-	+ [General]({{< ref "#general" >}})
-		- [I see errors like: Server access Error: Connection timed out url=http://archive.apache.org/dist/hadoop/core/hadoop-0.20.1/hadoop-0.20.1.tar.gz]({{< ref "#i-see-errors-like:-server-access-error:-connection-timed-out-url=http://archive-apache-org/dist/hadoop/core/hadoop-0-20-1/hadoop-0-20-1-tar-gz" >}})
-		- [How to change the warehouse.dir location for older tables?]({{< ref "#how-to-change-the-warehousedir-location-for-older-tables" >}})
-		- [When running a JOIN query, I see out-of-memory errors.]({{< ref "#when-running-a-join-query-i-see-out-of-memory-errors" >}})
-		- [I am using MySQL as metastore and I see errors: "com.mysql.jdbc.exceptions.jdbc4.!CommunicationsException: Communications link failure"]({{< ref "#mysql-excpeption" >}})
-		- [Does Hive support Unicode?]({{< ref "#does-hive-support-unicode" >}})
-	+ [Hive SQL]({{< ref "#hive-sql" >}})
-		- [Are Hive SQL identifiers (e.g. table names, column names, etc) case sensitive?]({{< ref "#are-hive-sql-identifiers-eg-table-names-column-names-etc-case-sensitive" >}})
-		- [What are the maximum allowed lengths for Hive SQL identifiers?]({{< ref "#what-are-the-maximum-allowed-lengths-for-hive-sql-identifiers" >}})
-	+ [Importing Data into Hive]({{< ref "#importing-data-into-hive" >}})
-		- [How do I import XML data into Hive?]({{< ref "#how-do-i-import-xml-data-into-hive" >}})
-		- [How do I import CSV data into Hive?]({{< ref "#how-do-i-import-csv-data-into-hive" >}})
-		- [How do I import JSON data into Hive?]({{< ref "#how-do-i-import-json-data-into-hive" >}})
-		- [How do I import Thrift data into Hive?]({{< ref "#how-do-i-import-thrift-data-into-hive" >}})
-		- [How do I import Avro data into Hive?]({{< ref "#how-do-i-import-avro-data-into-hive" >}})
-		- [How do I import delimited text data into Hive?]({{< ref "#how-do-i-import-delimited-text-data-into-hive" >}})
-		- [How do I import fixed-width data into Hive?]({{< ref "#how-do-i-import-fixed-width-data-into-hive" >}})
-		- [How do I import ASCII logfiles (HTTP, etc) into Hive?]({{< ref "#how-do-i-import-ascii-logfiles-http-etc-into-hive" >}})
-	+ [Exporting Data from Hive]({{< ref "#exporting-data-from-hive" >}})
-	+ [Hive Data Model]({{< ref "#hive-data-model" >}})
-		- [What is the difference between a native table and an external table?]({{< ref "#what-is-the-difference-between-a-native-table-and-an-external-table" >}})
-		- [What are dynamic partitions?]({{< ref "#what-are-dynamic-partitions" >}})
-		- [Can a Hive table contain data in more than one format?]({{< ref "#can-a-hive-table-contain-data-in-more-than-one-format" >}})
-		- [Is it possible to set the data format on a per-partition basis?]({{< ref "#is-it-possible-to-set-the-data-format-on-a-per-partition-basis" >}})
-	+ [JDBC Driver]({{< ref "#jdbc-driver" >}})
-		- [Does Hive have a JDBC Driver?]({{< ref "#does-hive-have-a-jdbc-driver" >}})
-	+ [ODBC Driver]({{< ref "#odbc-driver" >}})
-		- [Does Hive have an ODBC driver?]({{< ref "#does-hive-have-an-odbc-driver" >}})
+{{< toc >}}
 
 ## General
 

--- a/content/docs/latest/using-tidb-as-the-hive-metastore-database_158872426.md
+++ b/content/docs/latest/using-tidb-as-the-hive-metastore-database_158872426.md
@@ -5,19 +5,9 @@ date: 2024-12-12
 
 # Apache Hive : Using TiDB as the Hive Metastore database
 
-# 
-* [Why use TiDB in Hive as the Metastore database?]({{< ref "#why-use-tidb-in-hive-as-the-metastore-database?" >}})
-* [How to create a Hive cluster with TiDB]({{< ref "#how-to-create-a-hive-cluster-with-tidb" >}})
-	+ [Components required]({{< ref "#components-required" >}})
-	+ [Install a Hive cluster]({{< ref "#install-a-hive-cluster" >}})
-		- [Step 1: Deploy a TiDB cluster]({{< ref "#step-1-deploy-a-tidb-cluster" >}})
-		- [Step 2: Configure Hive]({{< ref "#step-2-configure-hive" >}})
-		- [Step 3: Initialize metadata]({{< ref "#step-3-initialize-metadata" >}})
-		- [Step 4: Launch Metastore and test]({{< ref "#step-4-launch-metastore-and-test" >}})
-* [Conclusion]({{< ref "#conclusion" >}})
-* [FAQ]({{< ref "#faq" >}})
+{{< toc >}}
 
-Why use TiDB in Hive as the Metastore database?
+# Why use TiDB in Hive as the Metastore database?
 
 [TiDB](https://github.com/pingcap/tidb) is a distributed SQL database built by [PingCAP](https://pingcap.com/) and its open-source community. **It is MySQL compatible and features horizontal scalability, strong consistency, and high availability.** It's a one-stop solution for both Online Transactional Processing (OLTP) and Online Analytical Processing (OLAP) workloads.
 

--- a/content/docs/latest/vectorized-query-execution_34838326.md
+++ b/content/docs/latest/vectorized-query-execution_34838326.md
@@ -5,13 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : Vectorized Query Execution
 
-* [Introduction]({{< ref "#introduction" >}})
-* [Using Vectorized Query Execution]({{< ref "#using-vectorized-query-execution" >}})
-	+ [Enabling vectorized execution]({{< ref "#enabling-vectorized-execution" >}})
-	+ [Supported data types and operations]({{< ref "#supported-data-types-and-operations" >}})
-	+ [Seeing whether vectorization is used for a query]({{< ref "#seeing-whether-vectorization-is-used-for-a-query" >}})
-* [Limitations]({{< ref "#limitations" >}})
-* [Version Information]({{< ref "#version-information" >}})
+{{< toc >}}
 
 # Introduction
 

--- a/content/docs/latest/viewdev_27362067.md
+++ b/content/docs/latest/viewdev_27362067.md
@@ -3,28 +3,9 @@ title: "Apache Hive : ViewDev"
 date: 2024-12-12
 ---
 
-# Apache Hive : ViewDev
+# Apache Hive : Views
 
-# Hive Views
-
-* [Hive Views]({{< ref "#hive-views" >}})
-	+ [Use Cases]({{< ref "#use-cases" >}})
-	+ [Scope]({{< ref "#scope" >}})
-	+ [Syntax]({{< ref "#syntax" >}})
-	+ [Implementation Sketch]({{< ref "#implementation-sketch" >}})
-	+ [Issues]({{< ref "#issues" >}})
-		- [Stored View Definition]({{< ref "#stored-view-definition" >}})
-		- [Metastore Modeling]({{< ref "#metastore-modeling" >}})
-		- [Dependency Tracking]({{< ref "#dependency-tracking" >}})
-		- [Dependency Invalidation]({{< ref "#dependency-invalidation" >}})
-		- [View Modification]({{< ref "#view-modification" >}})
-		- [Fast Path Execution]({{< ref "#fast-path-execution" >}})
-		- [ORDER BY and LIMIT in view definition]({{< ref "#order-by-and-limit-in-view-definition" >}})
-		- [Underlying Partition Dependencies]({{< ref "#underlying-partition-dependencies" >}})
-	+ [Metastore Upgrades]({{< ref "#metastore-upgrades" >}})
-		- [Automatic ALTER TABLE]({{< ref "#automatic-alter-table" >}})
-		- [Explicit ALTER TABLE]({{< ref "#explicit-alter-table" >}})
-		- [Existing Row UPDATE]({{< ref "#existing-row-update" >}})
+{{< toc >}}
 
 ## Use Cases
 

--- a/content/docs/latest/webhcat-configure_34015738.md
+++ b/content/docs/latest/webhcat-configure_34015738.md
@@ -5,12 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Configure
 
-# WebHCat Configuration
-
-* [WebHCat Configuration]({{< ref "#webhcat-configuration" >}})
-	+ [Configuration Files]({{< ref "#configuration-files" >}})
-	+ [Configuration Variables]({{< ref "#configuration-variables" >}})
-		- [Default Values]({{< ref "#default-values" >}})
+{{< toc >}}
 
 ## Configuration Files
 

--- a/content/docs/latest/webhcat-installwebhcat_34015585.md
+++ b/content/docs/latest/webhcat-installwebhcat_34015585.md
@@ -3,23 +3,11 @@ title: "Apache Hive : WebHCat InstallWebHCat"
 date: 2024-12-12
 ---
 
-# Apache Hive : WebHCat InstallWebHCat
+# Apache Hive : WebHCat Installation
 
-# WebHCat Installation
-
-* [WebHCat Installation]({{< ref "#webhcat-installation" >}})
-	+ [WebHCat Installed with Hive]({{< ref "#webhcat-installed-with-hive" >}})
-	+ [WebHCat Installation Procedure]({{< ref "#webhcat-installation-procedure" >}})
-	+ [Server Commands]({{< ref "#server-commands" >}})
-	+ [Requirements]({{< ref "#requirements" >}})
-	+ [Hadoop Distributed Cache]({{< ref "#hadoop-distributed-cache" >}})
-	+ [Permissions]({{< ref "#permissions" >}})
-	+ [Secure Cluster]({{< ref "#secure-cluster" >}})
-	+ [Proxy User Support]({{< ref "#proxy-user-support" >}})
+{{< toc >}}
 
 ## WebHCat Installed with Hive
-
-Version
 
 WebHCat and HCatalog are installed with Hive, starting with Hive release 0.11.0.
 

--- a/content/docs/latest/webhcat-reference-ddl_34015990.md
+++ b/content/docs/latest/webhcat-reference-ddl_34015990.md
@@ -5,17 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference DDL
 
-# DDL Command — POST ddl
-
-* [DDL Command — POST ddl]({{< ref "#ddl-command--post-ddl" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
-		- [JSON Output (error)]({{< ref "#json-output-error" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-deletedb_34016281.md
+++ b/content/docs/latest/webhcat-reference-deletedb_34016281.md
@@ -5,17 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference DeleteDB
 
-# Delete Database — DELETE ddl/database/:db
-
-* [Delete Database — DELETE ddl/database/:db]({{< ref "#delete-database--delete-ddldatabasedb" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
-		- [JSON Output (error)]({{< ref "#json-output-error" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-deletejob_34017204.md
+++ b/content/docs/latest/webhcat-reference-deletejob_34017204.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference DeleteJob
 
-# Delete Job — DELETE queue/:jobid
-
-* [Delete Job — DELETE queue/:jobid]({{< ref "#delete-job--delete-queuejobid" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-deletejobid_34835045.md
+++ b/content/docs/latest/webhcat-reference-deletejobid_34835045.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference DeleteJobID
 
-# Delete Job — DELETE jobs/:jobid
-
-* [Delete Job — DELETE jobs/:jobid]({{< ref "#delete-job--delete-jobsjobid" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-deletepartition_34016611.md
+++ b/content/docs/latest/webhcat-reference-deletepartition_34016611.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference DeletePartition
 
-# Delete Partition — DELETE ddl/database/:db/table/:table/partition/:partition
-
-* [Delete Partition — DELETE ddl/database/:db/table/:table/partition/:partition]({{< ref "#delete-partition--delete-ddldatabasedbtabletablepartitionpartition" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-deletetable_34016561.md
+++ b/content/docs/latest/webhcat-reference-deletetable_34016561.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference DeleteTable
 
-# Delete Table — DELETE ddl/database/:db/table/:table
-
-* [Delete Table — DELETE ddl/database/:db/table/:table]({{< ref "#delete-table--delete-ddldatabasedbtabletable" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-getcolumn_34016979.md
+++ b/content/docs/latest/webhcat-reference-getcolumn_34016979.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference GetColumn
 
-# Describe Column — GET ddl/database/:db/table/:table/column/:column
-
-* [Describe Column — GET ddl/database/:db/table/:table/column/:column]({{< ref "#describe-column--get-ddldatabasedbtabletablecolumncolumn" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-getcolumns_34016970.md
+++ b/content/docs/latest/webhcat-reference-getcolumns_34016970.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference GetColumns
 
-# List Columns — GET ddl/database/:db/table/:table/column
-
-* [List Columns — GET ddl/database/:db/table/:table/column]({{< ref "#list-columns--get-ddldatabasedbtabletablecolumn" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-getdb_34016250.md
+++ b/content/docs/latest/webhcat-reference-getdb_34016250.md
@@ -5,17 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference GetDB
 
-# Describe Database — GET ddl/database/:db
-
-* [Describe Database — GET ddl/database/:db]({{< ref "#describe-database--get-ddldatabasedb" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
-		- [JSON Output (error)]({{< ref "#json-output-error" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-getdbs_34016238.md
+++ b/content/docs/latest/webhcat-reference-getdbs_34016238.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference GetDBs
 
-# List Databases — GET ddl/database
-
-* [List Databases — GET ddl/database]({{< ref "#list-databases--get-ddldatabase" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-getpartition_34016592.md
+++ b/content/docs/latest/webhcat-reference-getpartition_34016592.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference GetPartition
 
-# Describe Partition — GET ddl/database/:db/table/:table/partition/:partition
-
-* [Describe Partition — GET ddl/database/:db/table/:table/partition/:partition]({{< ref "#describe-partition--get-ddldatabasedbtabletablepartitionpartition" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-getpartitions_34016583.md
+++ b/content/docs/latest/webhcat-reference-getpartitions_34016583.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference GetPartitions
 
-# List Partitions — GET ddl/database/:db/table/:table/partition
-
-* [List Partitions — GET ddl/database/:db/table/:table/partition]({{< ref "#list-partitions--get-ddldatabasedbtabletablepartition" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-getproperties_34016995.md
+++ b/content/docs/latest/webhcat-reference-getproperties_34016995.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference GetProperties
 
-# List Properties — GET ddl/database/:db/table/:table/property
-
-* [List Properties — GET ddl/database/:db/table/:table/property]({{< ref "#list-properties--get-ddldatabasedbtabletableproperty" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-getproperty_34017004.md
+++ b/content/docs/latest/webhcat-reference-getproperty_34017004.md
@@ -5,17 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference GetProperty
 
-# Property Value — GET ddl/database/:db/table/:table/property/:property
-
-* [Property Value — GET ddl/database/:db/table/:table/property/:property]({{< ref "#property-value--get-ddldatabasedbtabletablepropertyproperty" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
-		- [JSON Output (error)]({{< ref "#json-output-error" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-gettable_34016519.md
+++ b/content/docs/latest/webhcat-reference-gettable_34016519.md
@@ -5,19 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference GetTable
 
-# Describe Table — GET ddl/database/:db/table/:table
-
-* [Describe Table — GET ddl/database/:db/table/:table]({{< ref "#describe-table--get-ddldatabasedbtabletable" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command (simple)]({{< ref "#curl-command-simple" >}})
-		- [JSON Output (simple)]({{< ref "#json-output-simple" >}})
-		- [Curl Command (extended)]({{< ref "#curl-command-extended" >}})
-		- [JSON Output (extended)]({{< ref "#json-output-extended" >}})
-		- [JSON Output (error)]({{< ref "#json-output-error" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-gettables_34016290.md
+++ b/content/docs/latest/webhcat-reference-gettables_34016290.md
@@ -5,17 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference GetTables
 
-# List Tables — GET ddl/database/:db/table
-
-* [List Tables — GET ddl/database/:db/table]({{< ref "#list-tables--get-ddldatabasedbtable" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
-		- [JSON Output (error)]({{< ref "#json-output-error" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-hive_34017180.md
+++ b/content/docs/latest/webhcat-reference-hive_34017180.md
@@ -5,17 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference Hive
 
-# Hive Job — POST hive
-
-* [Hive Job — POST hive]({{< ref "#hive-job--post-hive" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
-		- [Example Results]({{< ref "#example-results" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-job_34835065.md
+++ b/content/docs/latest/webhcat-reference-job_34835065.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference Job
 
-# Job Information — GET jobs/:jobid
-
-* [Job Information — GET jobs/:jobid]({{< ref "#job-information--get-jobsjobid" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-jobids_34017187.md
+++ b/content/docs/latest/webhcat-reference-jobids_34017187.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference JobIDs
 
-# List JobIDs — GET queue
-
-* [List JobIDs — GET queue]({{< ref "#list-jobids--get-queue" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-jobinfo_34017194.md
+++ b/content/docs/latest/webhcat-reference-jobinfo_34017194.md
@@ -5,17 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference JobInfo
 
-# Job Information — GET queue/:jobid
-
-* [Job Information — GET queue/:jobid]({{< ref "#job-information--get-queuejobid" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
-		- [JSON Output (Hive 0.12.0 and later)]({{< ref "#json-output-hive-0120-and-later" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-jobs_34835057.md
+++ b/content/docs/latest/webhcat-reference-jobs_34835057.md
@@ -5,20 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference Jobs
 
-# List JobIDs — GET jobs
-
-* [List JobIDs — GET jobs]({{< ref "#list-jobids--get-jobs" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Examples]({{< ref "#examples" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
-		- [Curl Command (showall)]({{< ref "#curl-command-showall" >}})
-		- [JSON Output (showall)]({{< ref "#json-output-showall" >}})
-		- [Curl Command (fields)]({{< ref "#curl-command-fields" >}})
-		- [JSON Output (fields)]({{< ref "#json-output-fields" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-mapreducejar_34017030.md
+++ b/content/docs/latest/webhcat-reference-mapreducejar_34017030.md
@@ -5,17 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference MapReduceJar
 
-# MapReduce Job — POST mapreduce/jar
-
-* [MapReduce Job — POST mapreduce/jar]({{< ref "#mapreduce-job--post-mapreducejar" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Code and Data Setup]({{< ref "#code-and-data-setup" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-mapreducestream_34017023.md
+++ b/content/docs/latest/webhcat-reference-mapreducestream_34017023.md
@@ -5,18 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference MapReduceStream
 
-# MapReduce Streaming Job — POST mapreduce/streaming
-
-* [MapReduce Streaming Job — POST mapreduce/streaming]({{< ref "#mapreduce-streaming-job--post-mapreducestreaming" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Code and Data Setup]({{< ref "#code-and-data-setup" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
-		- [Example Results]({{< ref "#example-results" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-pig_34017169.md
+++ b/content/docs/latest/webhcat-reference-pig_34017169.md
@@ -5,17 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference Pig
 
-# Pig Job — POST pig
-
-* [Pig Job — POST pig]({{< ref "#pig-job--post-pig" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Code and Data Setup]({{< ref "#code-and-data-setup" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-posttable_34016548.md
+++ b/content/docs/latest/webhcat-reference-posttable_34016548.md
@@ -5,17 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference PostTable
 
-# Rename Table — POST ddl/database/:db/table/:table
-
-* [Rename Table — POST ddl/database/:db/table/:table]({{< ref "#rename-table--post-ddldatabasedbtabletable" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
-		- [JSON Output (error)]({{< ref "#json-output-error" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-putcolumn_34016987.md
+++ b/content/docs/latest/webhcat-reference-putcolumn_34016987.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference PutColumn
 
-# Create Column — PUT ddl/database/:db/table/:table/column/:column
-
-* [Create Column — PUT ddl/database/:db/table/:table/column/:column]({{< ref "#create-column--put-ddldatabasedbtabletablecolumncolumn" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-putdb_34016273.md
+++ b/content/docs/latest/webhcat-reference-putdb_34016273.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference PutDB
 
-# Create Database — PUT ddl/database/:db
-
-* [Create Database — PUT ddl/database/:db]({{< ref "#create-database--put-ddldatabasedb" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-putpartition_34016600.md
+++ b/content/docs/latest/webhcat-reference-putpartition_34016600.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference PutPartition
 
-# Create Partition — PUT ddl/database/:db/table/:table/partition/:partition
-
-* [Create Partition — PUT ddl/database/:db/table/:table/partition/:partition]({{< ref "#create-partition--put-ddldatabasedbtabletablepartitionpartition" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-putproperty_34017012.md
+++ b/content/docs/latest/webhcat-reference-putproperty_34017012.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference PutProperty
 
-# Set Property — PUT ddl/database/:db/table/:table/property/:property
-
-* [Set Property — PUT ddl/database/:db/table/:table/property/:property]({{< ref "#set-property--put-ddldatabasedbtabletablepropertyproperty" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-puttable_34016540.md
+++ b/content/docs/latest/webhcat-reference-puttable_34016540.md
@@ -5,18 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference PutTable
 
-# Create Table — PUT ddl/database/:db/table/:table
-
-* [Create Table — PUT ddl/database/:db/table/:table]({{< ref "#create-table--put-ddldatabasedbtabletable" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [Curl Command (using clusteredBy)]({{< ref "#curl-command-using-clusteredby" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
-		- [JSON Output (error)]({{< ref "#json-output-error" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-puttablelike_34016572.md
+++ b/content/docs/latest/webhcat-reference-puttablelike_34016572.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference PutTableLike
 
-# Create Table Like — PUT ddl/database/:db/table/:existingtable/like/:newtable
-
-* [Create Table Like — PUT ddl/database/:db/table/:existingtable/like/:newtable]({{< ref "#create-table-like--put-ddldatabasedbtableexistingtablelikenewtable" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-responsetypes_34015937.md
+++ b/content/docs/latest/webhcat-reference-responsetypes_34015937.md
@@ -5,17 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference ResponseTypes
 
-# Response Types — GET :version
-
-* [Response Types — GET :version]({{< ref "#response-types--get-version" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
-		- [JSON Output (error)]({{< ref "#json-output-error" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-status_34015941.md
+++ b/content/docs/latest/webhcat-reference-status_34015941.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference Status
 
-# Current Status — GET status
-
-* [Current Status — GET status]({{< ref "#current-status--get-status" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-version_34015986.md
+++ b/content/docs/latest/webhcat-reference-version_34015986.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference Version
 
-# List Versions — GET version
-
-* [List Versions — GET version]({{< ref "#list-versions--get-version" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-versionhadoop_44303410.md
+++ b/content/docs/latest/webhcat-reference-versionhadoop_44303410.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference VersionHadoop
 
-# Hadoop Version — GET version/hadoop
-
-* [Hadoop Version — GET version/hadoop]({{< ref "#hadoop-version--get-versionhadoop" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-reference-versionhive_44303406.md
+++ b/content/docs/latest/webhcat-reference-versionhive_44303406.md
@@ -5,16 +5,7 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat Reference VersionHive
 
-# Hive Version — GET version/hive
-
-* [Hive Version — GET version/hive]({{< ref "#hive-version--get-versionhive" >}})
-	+ [Description]({{< ref "#description" >}})
-	+ [URL]({{< ref "#url" >}})
-	+ [Parameters]({{< ref "#parameters" >}})
-	+ [Results]({{< ref "#results" >}})
-	+ [Example]({{< ref "#example" >}})
-		- [Curl Command]({{< ref "#curl-command" >}})
-		- [JSON Output]({{< ref "#json-output" >}})
+{{< toc >}}
 
 ## Description
 

--- a/content/docs/latest/webhcat-usingwebhcat_34015492.md
+++ b/content/docs/latest/webhcat-usingwebhcat_34015492.md
@@ -5,21 +5,9 @@ date: 2024-12-12
 
 # Apache Hive : WebHCat UsingWebHCat
 
-# Using the HCatalog REST API (WebHCat)
+{{< toc >}}
 
-* [Using the HCatalog REST API (WebHCat)]({{< ref "#using-the-hcatalog-rest-api-webhcat" >}})
-	+ [Introduction to WebHCat]({{< ref "#introduction-to-webhcat" >}})
-	+ [URL Format]({{< ref "#url-format" >}})
-	+ [Security]({{< ref "#security" >}})
-		- [Standard Parameters]({{< ref "#standard-parameters" >}})
-			* [Specifying user.name]({{< ref "#specifying-username" >}})
-		- [Security Error Response]({{< ref "#security-error-response" >}})
-	+ [WebHDFS and Code Push]({{< ref "#webhdfs-and-code-push" >}})
-	+ [Error Codes and Responses]({{< ref "#error-codes-and-responses" >}})
-	+ [Log Files]({{< ref "#log-files" >}})
-	+ [Project Name]({{< ref "#project-name" >}})
-
-Version information
+## Version information
 
 The HCatalog project graduated from the Apache incubator and merged with the Hive project on March 26, 2013.  
  Hive version 0.11.0 is the first release that includes HCatalog and its REST API, WebHCat.

--- a/themes/hive/static/css/hive-theme.css
+++ b/themes/hive/static/css/hive-theme.css
@@ -352,6 +352,11 @@ li {
   font-size: 1.2rem;
 }
 
+/* Hide empty list bullets inside the table of contents */
+.table-of-contents li:not(:has(a)) {
+    display: none;
+}
+
 pre,
 code {
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;


### PR DESCRIPTION
1. Replace hardcoded tables with toc placeholder
2. Rework some headers content around the toc for better readability
3. Fix a few JIRA links to avoid bad entries in the table of contents
4. Add css rule to hide list elements in the table of contents that are empty (known issue in Hugo)
5. Configure the tableOfContents generation to consider headers from level-1 to level-3

The change aims to reduce boilerplate code, facilitate maintenance, enforce uniform style, and improve page evolution.

The changes were done & verified manually, since crafting an automated script to perform this task was pretty cumbersome given that the content is not uniform.