### PR TITLE
Refine how to release doc

### DIFF
--- a/content/community/resources/howtorelease_27362106.md
+++ b/content/community/resources/howtorelease_27362106.md
@@ -256,7 +256,6 @@ hive-standalone-metastore-X.Y.Z-src.tar.gz: OK
 4. Check that release file looks ok -- e.g., install it and run examples from tutorial.
 5. Setup your PGP keys for signing the release, if you don't have them already.
 	1. See <https://www.apache.org/dev/release-signing.html>, <https://www.apache.org/dev/openpgp.html>.
-    2. You may need PMC privileges to do this step – if you do not have such privileges, please ping a [PMC member](http://hive.apache.org/people.html) to do this for you. 
 
 ```
 % gpg --full-generate-key
@@ -433,7 +432,7 @@ git push origin :release-X.Y.Z-rcR
 If errors happen while "git tag -s", try to configure the git signing key by "git config user.signingkey your_gpg_key_id" then rerun the command.  
 This step (`git push origin rel/release-X.Y.Z`) will trigger the Hive Docker image build and upload to Docker Hub on the [Hive Action Page](https://github.com/apache/hive/actions/workflows/docker-GA-images.yml). If the image build fails, click **Re-run** on the Actions page to retry or manually build and upload it. Finally, verify whether the image has been successfully uploaded by checking the [Docker Hub](https://hub.docker.com/r/apache/hive/tags).
 
-2. Move the release artifacts to the release area of the project (<https://dist.apache.org/repos/dist/release/hive/>). Using svn mv command is important otherwise you may hit size limitations applying to artifacts([INFRA-23055](https://issues.apache.org/jira/browse/INFRA-23055)). You may need PMC privileges to do this step – if you do not have such privileges, please ping a [PMC member](http://hive.apache.org/people.html) to do this for you.
+2. Move the release artifacts to the release area of the project (<https://dist.apache.org/repos/dist/release/hive/>). Using svn mv command is important otherwise you may hit size limitations applying to artifacts([INFRA-23055](https://issues.apache.org/jira/browse/INFRA-23055)).
 
 ```
 svn mv https://dist.apache.org/repos/dist/dev/hive/hive-X.Y.Z https://dist.apache.org/repos/dist/release/hive/hive-X.Y.Z -m "Move hive-X.Y.Z release from dev to release"
@@ -532,7 +531,7 @@ The Apache Hive Team
 
 ### Archive old releases
 
-According to the [INFRA archival g](https://infra.apache.org/release-distribution.html#archival)[uidelines](https://infra.apache.org/release-distribution.html#archival) old releases should be removed from the main [download site of the project](https://downloads.apache.org/hive/) following. Check the respective guidelines and perform the necessary cleanup. You may need PMC privileges to do this step – if you do not have such privileges, please ping a [PMC member](http://hive.apache.org/people.html) to do this for you.
+According to the [INFRA archival g](https://infra.apache.org/release-distribution.html#archival)[uidelines](https://infra.apache.org/release-distribution.html#archival) old releases should be removed from the main [download site of the project](https://downloads.apache.org/hive/) following. Check the respective guidelines and perform the necessary cleanup.
 
 ```
 svn del -m "Archiving release Apache Hive X.Y.Z" https://dist.apache.org/repos/dist/release/hive/hive-X.Y.Z/ 

--- a/content/community/resources/howtorelease_27362106.md
+++ b/content/community/resources/howtorelease_27362106.md
@@ -237,6 +237,7 @@ git push origin release-X.Y.Z-rcR
 ```
 
 Note: If you build from the existing project, make sure there are no empty directories or the "*.iml" files in the apache-hive-X.Y.Z-src.tar.gz.
+
 3. Verify that the SHA 256 checksums are valid:
 
 ```
@@ -423,13 +424,15 @@ Once [three PMC members have voted for a release](http://www.apache.org/foundati
 1. Tag the release and delete the release candidate tag. Do it from the release branch:
 
 ```
-git tag -s rel/release-X.Y.Z -m "HiveX.Y.Z release."
+git tag -s rel/release-X.Y.Z -m "Hive X.Y.Z release."
 git push origin rel/release-X.Y.Z
 git tag -d release-X.Y.Z-rcR
 git push origin :release-X.Y.Z-rcR
 ```
+**NOTE:**  
+If errors happen while "git tag -s", try to configure the git signing key by "git config user.signingkey your_gpg_key_id" then rerun the command.  
+This step (`git push origin rel/release-X.Y.Z`) will trigger the Hive Docker image build and upload to Docker Hub on the [Hive Action Page](https://github.com/apache/hive/actions/workflows/docker-GA-images.yml). If the image build fails, click **Re-run** on the Actions page to retry or manually build and upload it. Finally, verify whether the image has been successfully uploaded by checking the [Docker Hub](https://hub.docker.com/r/apache/hive/tags).
 
-If errors happen while "git tag -s", try to configure the git signing key by "git config user.signingkey your_gpg_key_id" then rerun the command.
 2. Move the release artifacts to the release area of the project (<https://dist.apache.org/repos/dist/release/hive/>). Using svn mv command is important otherwise you may hit size limitations applying to artifacts([INFRA-23055](https://issues.apache.org/jira/browse/INFRA-23055)). You may need PMC privileges to do this step – if you do not have such privileges, please ping a [PMC member](http://hive.apache.org/people.html) to do this for you.
 
 ```
@@ -443,7 +446,8 @@ svn mv https://dist.apache.org/repos/dist/dev/hive/hive-standalone-metastore-X.Y
 mvn clean install javadoc:javadoc javadoc:aggregate -Pjavadoc -DskipTests
 ```
 
-After you run this, you should have javadocs present in your <hive_source_dir>/target/site/apidocs
+After you run this, you should have javadocs present in your <hive_source_dir>/target/site/apidocs.
+
 5. Check out the javadocs svn repository as follows:
 
 ```
@@ -460,6 +464,7 @@ svn commit -m "Hive X.Y.Z javadocs"
 ```
 
 If this is a bugfix release, svn rm the obsoleted version. (For eg., when committing javadocs for r0.13.1, r0.13.0 would have been removed)
+
 7. Prepare to edit the website.
 
 ```


### PR DESCRIPTION
During the process of releasing version 4.1.0, I identified several areas for improvement in the "how to release" documentation:  

1) Uploading to or deleting from the release directory https://dist.apache.org/repos/dist/release/hive using SVN requires PMC permissions.  

2) The content at https://reporter.apache.org/addrelease.html?hive requires PMC permissions to fill out.  

3) The description of the Javadoc execution steps is confusing.  

4) The content of the Release Candidate voting email can be optimized.

5）Add note about when to build the image.