### PR TITLE
HIVE-29379: Handle Website Checks violations

### DIFF
--- a/themes/hive/layouts/partials/footer.html
+++ b/themes/hive/layouts/partials/footer.html
@@ -36,9 +36,9 @@
                 If you discover any
                 <a href="{{ .Site.Params.apache.security }}">security</a> vulnerabilities, please
                 report them privately. Finally,
-                <a href="{{ .Site.Params.apache.sponsors }}">thanks
+                <a href="{{ .Site.Params.apache.thanks }}">thanks
                 </a> to the sponsors who
-                <a href="{{ .Site.Params.apache.donate }}">
+                <a href="{{ .Site.Params.apache.sponsors }}">
                     donate</a> to the Apache Foundation.
             </p>
         </div>


### PR DESCRIPTION
- https://issues.apache.org/jira/browse/HIVE-29379
- https://whimsy.apache.org/site/project/hive

> URL expected to match regular expression: ^https?://.*apache.org/foundation/sponsorship
> "Sponsorship", "Sponsor Apache", or "Donate" should link to: http://www.apache.org/foundation/sponsorship.html