### PR TITLE
Update hugo to 0.155.1

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -34,15 +34,15 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.91.2'
+          hugo-version: '0.155.1'
           # extended: true
 
       - name: Build


### PR DESCRIPTION
As discussed in https://github.com/apache/hive-site/pull/78#discussion_r2732854305, updating Hugo fixes some formatting issues. Here a PR that updates Hugo to the latest version.

There are some [warnings in the build](https://github.com/apache/hive-site/actions/runs/21561204372/job/62125463190?pr=93), `WARN  Raw HTML omitted`, so I looked for the cause. I think it's because of a [code listing that contains generics](https://github.com/apache/hive-site/blob/ed1b5d22cef718b7c3ffc11a8202ac4bfde55722/content/Development/desingdocs/column-statistics-in-hive.md?plain=1#L186), ` 2: required list<ColumnStatisticsObj> statsObj; `. The `<...>` are interpreted as an invalid HTML tag. In the current [rendering](https://hive.apache.org//development/desingdocs/column-statistics-in-hive/) (with version 0.91.2) the `<ColumnStatisticsObj>` is missing. So the previous version has the same problem, it just does not show the warnings.

I've downloaded the artifact (from the build in [Upload site artifact](https://github.com/apache/hive-site/actions/runs/21561204372/job/62125463190?pr=93)), launched a webserver (`busybox httpd -v -f -p 127.0.0.1:8080`), and checked a few pages. They look the same with a few improvements:

* superfluous lines at the end of code listings are removed
* the superfluous apostrophes mentioned in https://github.com/apache/hive-site/pull/78#discussion_r2732854305 are removed as well