### PR TITLE
Remove ref shortcuts for mail addresses

### DIFF
--- a/content/community/bylaws.md
+++ b/content/community/bylaws.md
@@ -68,7 +68,7 @@ Within the Hive project, different types of decisions require different forms of
 
 ### Voting
 
-Decisions regarding the project are made by votes on the primary project development mailing list ([user@hive.apache.org]({{< ref "mailto:user@pig-apache-org" >}})). Where necessary, PMC voting may take place on the private Hive PMC mailing list. Votes are clearly indicated by subject line starting with [VOTE]. Votes may contain multiple items for approval and these should be clearly separated. Voting is carried out by replying to the vote mail. Voting may take four flavors
+Decisions regarding the project are made by votes on the primary project development mailing list ([dev@hive.apache.org](mailto:dev@hive.apache.org)). Where necessary, PMC voting may take place on the private Hive PMC mailing list. Votes are clearly indicated by subject line starting with [VOTE]. Votes may contain multiple items for approval and these should be clearly separated. Voting is carried out by replying to the vote mail. Voting may take four flavors
 
 | Vote | Meaning |
 | --- | --- |

--- a/content/community/resources/howtocommit.md
+++ b/content/community/resources/howtocommit.md
@@ -17,7 +17,7 @@ New committers are encouraged to first read Apache's generic committer documenta
 
 The first act of a new core committer is typically to add their name to the [credits](/community/people/) page. This requires changing the source in <https://github.com/apache/hive-site/blob/main/content/community/people.md>
 
-Committers are strongly encouraged to subscribe to the [security@hive.apache.org]({{< ref "mailto:security-subscribe@hive-apache-org" >}}) list with their Apache email and help addressing security vulnerability reports.
+Committers are strongly encouraged to subscribe to the [security@hive.apache.org](mailto:security-subscribe@hive.apache.org) list with their Apache email and help addressing security vulnerability reports.
 
 ## Review
 

--- a/content/community/resources/howtorelease.md
+++ b/content/community/resources/howtorelease.md
@@ -104,7 +104,7 @@ sftp> cd hive-storage-X.Y.Z
 sftp> put hive-storage-X.Y.Z-rcR.tar.gz*
 sftp> quit
 ```
-8. Send email to [dev@hive.apache.org]({{< ref "mailto:dev@hive-apache-org" >}}) calling the vote.
+8. Send email to [dev@hive.apache.org](mailto:dev@hive.apache.org) calling the vote.
 
 ### Publishing the Storage API Artifacts
 

--- a/content/docs/latest/language/apache-hive-sql-conformance.md
+++ b/content/docs/latest/language/apache-hive-sql-conformance.md
@@ -17,7 +17,7 @@ The formal name of the current SQL standard is ISO/IEC 9075 "Database Language S
 | Apache Hive 2.3 | [Supported SQL Features](/docs/latest/language/supported-features-apache-hive-2-3) |
 | Apache Hive 3.1 | [Supported SQL Features]({{< ref "supported-features" >}}) |
 
-Information in these pages is not guaranteed to be accurate. Corrections can be submitted to the Apache Hive mailing list at [user@hive.apache.org]({{< ref "mailto:user@hive-apache-org" >}}).
+Information in these pages is not guaranteed to be accurate. Corrections can be submitted to the Apache Hive mailing list at [user@hive.apache.org](mailto:user@hive.apache.org).
 
  
 


### PR DESCRIPTION
Remove the unnecessary ref shortcut for email addresses (and fix one of the mail addresses).