### PR TITLE
Fail build if there are warnings

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -46,7 +46,7 @@ jobs:
           # extended: true
 
       - name: Build
-        run: hugo --minify
+        run: hugo --minify --panicOnWarning
 
       - name: Copy .asf.yaml
         run: cp .asf.yaml ./public


### PR DESCRIPTION
This PR adds `--panicOnWarning`, so that builds fail if Hugo encounters any warning (e.g., `Raw HTML omitted`).

I've opened another PR to validate the desired behavior: https://github.com/apache/hive-site/pull/108.